### PR TITLE
Sort images by tags

### DIFF
--- a/internal/dockertag/cache.go
+++ b/internal/dockertag/cache.go
@@ -204,6 +204,10 @@ func (c *Cache) getImagesFromSeveralRepositories(repositories []string) ([]Image
 			merged = append(merged, img)
 		}
 	}
+	
+	sort.Slice(merged, func(i, j int) bool {
+    		return merged[i].Tag > merged[j].Tag
+	})
 
 	return merged, imgByTag, nil
 }


### PR DESCRIPTION
The sorting of the versions on the website is a bit random, this is an attempt to fix it

<img width="257" alt="image" src="https://user-images.githubusercontent.com/43110995/199378096-e996d9fb-f327-47d6-8bb1-2e6b49f4cc0c.png">
