### PR TITLE
Disable network in containers

### DIFF
--- a/internal/qrunner/dockerengine/runner.go
+++ b/internal/qrunner/dockerengine/runner.go
@@ -254,9 +254,11 @@ func (r *Runner) runContainer(ctx context.Context, state *requestState) (err err
 		r.pipelineMetr.CreateContainer(err == nil, state.version, invokedAt)
 	}()
 
+	// Network is disabled to prevent malicious attacks and to optimize container start up.
 	contConfig := &container.Config{
-		Image:  state.chpImageName,
-		Labels: qrunner.CreateContainerLabels(state.runID, state.version),
+		Image:           state.chpImageName,
+		Labels:          qrunner.CreateContainerLabels(state.runID, state.version),
+		NetworkDisabled: true,
 	}
 
 	hostConfig := &container.HostConfig{


### PR DESCRIPTION
Network is disabled to prevent malicious attacks and to optimize container start up.

With a network access, uses can access some internal IPs or download malicious software. And this behavior is not supervised.

Furthermore, by default Docker creates a bridge network namespace, and it requires some time. According to "Locality-aware Load-Balancing For Serverless Clusters (Fuerst, Sharma)", it takes ~100 ms (we've seen the same results):
> An even larger source of scalability bottleneck is network names- pace creation time. Using the default bridge networking requires each invocation to create a new TUN/TAP network interface. We found this to be a very expensive operation because of Linux net- work stack overheads (several 100 ms), and because of dockerd’s userspace lock (futex) contention for its networking database. We found that as the historical total number of containers launched grows, so does the size of the network-interface database. Dockerd reads and updates this database under the critical section, and the larger database results in higher lock contention. As a result, we were unable to use VMs/servers with more than 4 CPUs after 20 minutes of sustained load, since the dockerd contention resulted in many functions timing out (timeout was 5 minutes)!

After that change queries that download something from the internet will be broken. There are plans to provide databases with a preloaded dataset to get around these limitations.