### PR TITLE
Allow to configure containers network mode

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -94,7 +94,7 @@ type DockerEngine struct {
 	QuotasPath       *string         `mapstructure:"quotas_path"`
 	GC               *DockerEngineGC `mapstructure:"gc"`
 
-	ContainerResources ContainerResources `mapstructure:"container_resources"`
+	Container ContainerSettings `mapstructure:"container"`
 }
 
 type DockerEngineGC struct {
@@ -106,7 +106,8 @@ type DockerEngineGC struct {
 	ImageBufferSize       uint  `mapstructure:"image_buffer_size"`
 }
 
-type ContainerResources struct {
+type ContainerSettings struct {
+	NetworkMode   *string `mapstucture:"network_mode"`
 	CPULimit      float64 `mapstructure:"cpu_limit"`
 	CPUSet        string  `mapstructure:"cpu_cores_set"`
 	MemoryLimitMB float64 `mapstructure:"memory_limit_mb"`

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -170,10 +170,11 @@ func initializeRunners(ctx context.Context, config *Config, awsConfig aws.Config
 				}
 			}
 
-			rcfg.Container = dockerengine.ContainerResources{
-				CPULimit:    uint64(r.DockerEngine.ContainerResources.CPULimit * 1e9), // cpu -> nano cpu.
-				CPUSet:      r.DockerEngine.ContainerResources.CPUSet,
-				MemoryLimit: uint64(r.DockerEngine.ContainerResources.MemoryLimitMB * 1e6), // mb -> bytes.
+			rcfg.Container = dockerengine.ContainerSettings{
+				NetworkMode: r.DockerEngine.Container.NetworkMode,
+				CPULimit:    uint64(r.DockerEngine.Container.CPULimit * 1e9), // cpu -> nano cpu.
+				CPUSet:      r.DockerEngine.Container.CPUSet,
+				MemoryLimit: uint64(r.DockerEngine.Container.MemoryLimitMB * 1e6), // mb -> bytes.
 			}
 
 			var err error

--- a/config.yml
+++ b/config.yml
@@ -138,7 +138,7 @@ runners:
       # You can limit resources usage for a Docker container.
       # Refer to the official Docker documentation for more detail:
       # https://docs.docker.com/config/containers/resource_constraints/
-      container_resources:
+      container:
         # Specify how much of the available CPU resources a container can use.
         # Docker cli: docker run --cpus=2.5
         # Default: unlimited.

--- a/deploy/config.yml
+++ b/deploy/config.yml
@@ -138,7 +138,7 @@ runners:
       # You can limit resources usage for a Docker container.
       # Refer to the official Docker documentation for more detail:
       # https://docs.docker.com/config/containers/resource_constraints/
-      container_resources:
+      container:
         # Specify how much of the available CPU resources a container can use.
         # Docker cli: docker run --cpus=2.5
         # Default: unlimited.

--- a/internal/qrunner/dockerengine/config.go
+++ b/internal/qrunner/dockerengine/config.go
@@ -19,10 +19,12 @@ type Config struct {
 
 	StatusCollectionFrequency time.Duration
 
-	Container ContainerResources
+	Container ContainerSettings
 }
 
-type ContainerResources struct {
+type ContainerSettings struct {
+	NetworkMode *string // Network mode to use for the container.
+
 	CPULimit    uint64 // In nano cpus (1 core = 1e9 nano cpus). If 0, then unlimited.
 	CPUSet      string // A comma-separated list or hyphen-separated range of CPUs a container can use. If "", then any cores can be used.
 	MemoryLimit uint64 // In bytes. If 0, then unlimited.
@@ -64,7 +66,8 @@ var DefaultConfig = Config{
 
 	StatusCollectionFrequency: 30 * time.Second,
 
-	Container: ContainerResources{
+	Container: ContainerSettings{
+		NetworkMode: nil,
 		CPULimit:    2 * 1e9,
 		CPUSet:      "",
 		MemoryLimit: 1 * 1e9,

--- a/internal/qrunner/dockerengine/runner.go
+++ b/internal/qrunner/dockerengine/runner.go
@@ -254,14 +254,19 @@ func (r *Runner) runContainer(ctx context.Context, state *requestState) (err err
 		r.pipelineMetr.CreateContainer(err == nil, state.version, invokedAt)
 	}()
 
-	// Network is disabled to prevent malicious attacks and to optimize container start up.
 	contConfig := &container.Config{
-		Image:           state.chpImageName,
-		Labels:          qrunner.CreateContainerLabels(state.runID, state.version),
-		NetworkDisabled: true,
+		Image:  state.chpImageName,
+		Labels: qrunner.CreateContainerLabels(state.runID, state.version),
 	}
 
+	var networkMode string
+	if r.cfg.Container.NetworkMode != nil {
+		networkMode = *r.cfg.Container.NetworkMode
+	}
+
+	// Network is disabled to prevent malicious attacks and to optimize container start up.
 	hostConfig := &container.HostConfig{
+		NetworkMode: container.NetworkMode(networkMode),
 		Resources: container.Resources{
 			NanoCPUs:   int64(r.cfg.Container.CPULimit),
 			CpusetCpus: r.cfg.Container.CPUSet,


### PR DESCRIPTION
According to the Docker docs, using the default bridge network mode is unsafe and not recommended: 
https://docs.docker.com/network/bridge/#differences-between-user-defined-bridges-and-the-default-bridge

Also, it would be nice if the coordinator controlled the network interfaces: better isolation + more straightforward deployment process. This patch allows specifying a network mode to use for containers and brings this goal closer.
