### PR TITLE
Fix vuln

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -30,8 +30,8 @@ services:
   #     - playground
   #   image: nginx/nginx-prometheus-exporter:0.10.0
   #   command: -nginx.scrape-uri="http://nginx:8080/stub_status"
-  #   ports:
-  #     - '9113:9113'
+  #   expose:
+  #     - '9113'
   #   restart: unless-stopped
   #   deploy:
   #     resources:
@@ -52,8 +52,8 @@ services:
       - '--storage.tsdb.retention.time=1y'
       - '--web.console.libraries=/usr/share/prometheus/console_libraries'
       - '--web.console.templates=/usr/share/prometheus/consoles'
-    ports:
-      - '9090:9090'
+    expose:
+      - '9090'
     restart: unless-stopped
     deploy:
       resources:
@@ -70,10 +70,10 @@ services:
       - /var/run:/var/run:rw
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
-    ports:
-      - '8080:8080'
     deploy:
       mode: global
+    expose:
+      - '8080'
     restart: unless-stopped
     deploy:
       resources:
@@ -111,8 +111,8 @@ services:
     volumes:
       - ./config.yml:/config.yml
       - /var/run/docker.sock:/var/run/docker.sock
-    ports:
-      - '9000:9000'
+    expose:
+      - '9000'
     restart: unless-stopped
     deploy:
       resources:

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -12,6 +12,10 @@ http {
 
         location = /stub_status {
             stub_status;
+
+            access_log off;
+            allow 172.17.0.0/16;
+            deny all;
         }
     }
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 
 require (
 	github.com/docker/cli v20.10.20+incompatible
-	github.com/docker/docker v20.10.20+incompatible
+	github.com/docker/docker v23.0.3+incompatible
 	github.com/gookit/config/v2 v2.1.0
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/docker/cli v20.10.20+incompatible h1:lWQbHSHUFs7KraSN2jOJK7zbMS2jNCHI
 github.com/docker/cli v20.10.20+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v20.10.20+incompatible h1:kH9tx6XO+359d+iAkumyKDc5Q1kOwPuAUaeri48nD6E=
-github.com/docker/docker v20.10.20+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v23.0.3+incompatible h1:9GhVsShNWz1hO//9BNg/dpMnZW25KydO4wtVxWAIbho=
+github.com/docker/docker v23.0.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=


### PR DESCRIPTION
Some vulnerabilities have been fixed:
- Docker package upgrade (reported by Dependabot)
- Deployed containers are hidden behind the nginx proxy, so they shouldn't expose ports externally
- Nginx stats must be available only from the internal network