### PR TITLE
Set default format to PrettyCompactMonoBlock

### DIFF
--- a/internal/qrunner/dockerengine/runner.go
+++ b/internal/qrunner/dockerengine/runner.go
@@ -324,7 +324,15 @@ func (r *Runner) exec(ctx context.Context, state *requestState) (stdout string, 
 		r.pipelineMetr.ExecCommand(err == nil, state.version, invokedAt)
 	}()
 
-	resp, err := r.engine.exec(ctx, state.containerID, []string{"clickhouse", "client", "-n", "-m", "--query", state.query})
+	args := []string{
+		"clickhouse", "client",
+		"-n",
+		"-m",
+		"--output_format_pretty_grid_charset", "ASCII",
+		"--output_format_pretty_color", "0",
+		"--query", state.query,
+	}
+	resp, err := r.engine.exec(ctx, state.containerID, args)
 	if err != nil {
 		return "", "", errors.Wrap(err, "exec failed")
 	}

--- a/pkg/chsemver/semver.go
+++ b/pkg/chsemver/semver.go
@@ -1,0 +1,44 @@
+package chsemver
+
+import (
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type Semver []string
+
+// Parse takes clickhouse version and splits it into semver-like representation.
+//
+// Example:
+// Parse("21.1.8") = ["21", "1", "8""]
+func Parse(version string) Semver {
+	return strings.FieldsFunc(version, func(r rune) bool {
+		return r == '.' || r == '-' || unicode.IsSpace(r)
+	})
+}
+
+// IsGreater takes two semver representations and returns true
+// if the first operand is greater than the second one.
+//
+// It can be used as a comparator in a sort-function.
+func IsGreater(a, b Semver) bool {
+	for i := 0; i < len(a) && i < len(b); i++ {
+		numA, errA := strconv.ParseUint(a[i], 10, 64)
+		numB, errB := strconv.ParseUint(b[i], 10, 64)
+
+		if errA == nil && errB == nil {
+			if numA != numB {
+				return numA > numB
+			}
+		} else {
+			return a[i] < b[i]
+		}
+	}
+
+	return len(a) > len(b)
+}
+
+func IsGreaterRaw(a, b string) bool {
+	return IsGreater(Parse(a), Parse(b))
+}

--- a/pkg/chsemver/semver_test.go
+++ b/pkg/chsemver/semver_test.go
@@ -1,0 +1,45 @@
+package chsemver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	cases := []struct {
+		Input    string
+		Expected []string
+	}{
+		{
+			Input:    "1.2.312",
+			Expected: []string{"1", "2", "312"},
+		},
+		{
+			Input:    "10.0",
+			Expected: []string{"10", "0"},
+		},
+		{
+			Input:    "20",
+			Expected: []string{"20"},
+		},
+		{
+			Input:    "1.2.3-alpine",
+			Expected: []string{"1", "2", "3", "alpine"},
+		},
+		{
+			Input:    "head",
+			Expected: []string{"head"},
+		},
+		{
+			Input:    "latest",
+			Expected: []string{"latest"},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.Input, func(t *testing.T) {
+			assert.EqualValues(t, Parse(test.Input), test.Expected)
+		})
+	}
+}


### PR DESCRIPTION
This PR improves output visualization by setting some output format options:
- Default format is `PrettyCompactMonoBlock` if CH version >= 20
- `output_format_pretty_color` is `0` if CH version >= 20
- `output_format_pretty_grid_charset` is `ASCII` if CH version **>= 22**

Version thresholds are set because these options are not supported in all CH client versions.

Closes #30