### PR TITLE
Prewarm containers

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -98,6 +98,7 @@ type DockerEngine struct {
 	CustomConfigPath *string         `mapstructure:"custom_config_path"`
 	QuotasPath       *string         `mapstructure:"quotas_path"`
 	GC               *DockerEngineGC `mapstructure:"gc"`
+	Prewarm          *Prewarm        `mapsctucture:"prewarm"`
 
 	Container ContainerSettings `mapstructure:"container"`
 }
@@ -109,6 +110,10 @@ type DockerEngineGC struct {
 
 	ImageGCCountThreshold *uint `mapstructure:"image_count_threshold"`
 	ImageBufferSize       uint  `mapstructure:"image_buffer_size"`
+}
+
+type Prewarm struct {
+	MaxWarmContainers *uint `mapstructure:"max_warm_containers"`
 }
 
 type ContainerSettings struct {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -134,7 +134,7 @@ func main() {
 	shutdownCtx, shutdown := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer shutdown()
 
-	err = coord.Stop()
+	err = coord.Stop(shutdownCtx)
 	if err != nil {
 		zlog.Err(err).Msg("coordinator cannot be stopped")
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -181,6 +181,10 @@ func initializeRunners(ctx context.Context, config *Config, awsConfig aws.Config
 				MemoryLimit: uint64(r.DockerEngine.Container.MemoryLimitMB * 1e6), // mb -> bytes.
 			}
 
+			if r.DockerEngine.Prewarm != nil && r.DockerEngine.Prewarm.MaxWarmContainers != nil {
+				rcfg.MaxWarmContainers = *r.DockerEngine.Prewarm.MaxWarmContainers
+			}
+
 			var err error
 			runner, err = dockerengine.New(ctx, logger, r.Name, rcfg, tagStorage)
 			if err != nil {

--- a/config.yml
+++ b/config.yml
@@ -160,4 +160,4 @@ runners:
       # in advance to optimize the process time.
       prewarm:
         # [OPTIONAL] Maximum number of prewarmed containers per worker.
-        max_warm_containers: 2
+        max_warm_containers: 5

--- a/config.yml
+++ b/config.yml
@@ -155,3 +155,9 @@ runners:
         # Docker cli: docker run --memory=1000m
         # Default: unlimited.
         memory_limit_mb: 1000
+
+      # [OPTIONAL] You can configure the prewarmer component that starts containers
+      # in advance to optimize the process time.
+      prewarm:
+        # [OPTIONAL] Maximum number of prewarmed containers per worker.
+        max_warm_containers: 2

--- a/internal/metrics/prewarmer.go
+++ b/internal/metrics/prewarmer.go
@@ -1,0 +1,68 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type PrewarmerExporter struct {
+	fetchesTotal         *prometheus.CounterVec
+	containersSetUpdates *prometheus.CounterVec
+}
+
+func NewPrewarmerExporter() *PrewarmerExporter {
+	return &PrewarmerExporter{
+		fetchesTotal: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "prewarmer",
+				Name:      "fetch_requests_total",
+				Help:      "How many fetch requests were dispatched.",
+			},
+			[]string{"status"},
+		),
+		containersSetUpdates: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "prewarmer",
+				Name:      "containers_set_updates_total",
+				Help:      "How many changes of containers set are done.",
+			},
+			[]string{"action"},
+		),
+	}
+}
+
+func (r *PrewarmerExporter) FetchHit() {
+	r.observeFetch("hit")
+}
+
+func (r *PrewarmerExporter) FetchMiss() {
+	r.observeFetch("miss")
+}
+
+func (r *PrewarmerExporter) observeFetch(status string) {
+	r.fetchesTotal.
+		With(prometheus.Labels{
+			"status": status,
+		}).
+		Inc()
+}
+
+func (r *PrewarmerExporter) AddContainer() {
+	r.observeUpdate("add")
+}
+
+func (r *PrewarmerExporter) FetchContainer() {
+	r.observeUpdate("fetch")
+}
+
+func (r *PrewarmerExporter) EjectContainer() {
+	r.observeUpdate("eject")
+}
+
+func (r *PrewarmerExporter) observeUpdate(action string) {
+	r.containersSetUpdates.
+		With(prometheus.Labels{
+			"action": action,
+		}).
+		Inc()
+}

--- a/internal/qrunner/coordinator/coordinator.go
+++ b/internal/qrunner/coordinator/coordinator.go
@@ -145,7 +145,7 @@ func (c *Coordinator) loopCheckLiveness(r *Runner) {
 }
 
 // Stop stops underlying runners and waits for the health checks to be finished.
-func (c *Coordinator) Stop() error {
+func (c *Coordinator) Stop(shutdownCtx context.Context) error {
 	c.cancel()
 
 	c.logger.Info().Msg("stopping coordinator")
@@ -155,7 +155,7 @@ func (c *Coordinator) Stop() error {
 			continue
 		}
 
-		err := r.underlying.Stop()
+		err := r.underlying.Stop(shutdownCtx)
 		if err != nil {
 			c.logger.Err(err).Str("underlying", r.underlying.Name()).Msg("runner cannot be stopped")
 		}

--- a/internal/qrunner/dockerengine/config.go
+++ b/internal/qrunner/dockerengine/config.go
@@ -19,6 +19,7 @@ type Config struct {
 
 	GC *GCConfig
 
+	MaxWarmContainers         uint
 	StatusCollectionFrequency time.Duration
 
 	Container ContainerSettings
@@ -68,6 +69,7 @@ var DefaultConfig = Config{
 		ImageBufferSize:       defaultImageBufferSize,
 	},
 
+	MaxWarmContainers:         5,
 	StatusCollectionFrequency: 30 * time.Second,
 
 	Container: ContainerSettings{

--- a/internal/qrunner/dockerengine/container.go
+++ b/internal/qrunner/dockerengine/container.go
@@ -1,0 +1,37 @@
+package dockerengine
+
+import (
+	"sync"
+	"time"
+)
+
+type containerStatus string
+
+const (
+	statusUnknown containerStatus = ""
+	statusRunning containerStatus = "RUNNING"
+	statusPaused  containerStatus = "PAUSED"
+	statusFetched containerStatus = "FETCHED"
+)
+
+type containerState struct {
+	lock sync.Mutex
+
+	id       string
+	imageFQN string
+
+	createdAt time.Time
+	status    containerStatus
+}
+
+func (c *containerState) acquireLock() (release func()) {
+	c.lock.Lock()
+
+	return func() {
+		c.lock.Unlock()
+	}
+}
+
+func (c *containerState) setStatus(s containerStatus) {
+	c.status = s
+}

--- a/internal/qrunner/dockerengine/engine_provider.go
+++ b/internal/qrunner/dockerengine/engine_provider.go
@@ -81,16 +81,16 @@ func (p *engineProvider) ownershipLabelFilter() (key, value string) {
 	return "label", qrunner.LabelOwnership
 }
 
-func (p *engineProvider) pullImage(ctx context.Context, name string) (io.ReadCloser, error) {
-	return p.cli.ImagePull(ctx, name, types.ImagePullOptions{})
+func (p *engineProvider) pullImage(ctx context.Context, imageTag string) (io.ReadCloser, error) {
+	return p.cli.ImagePull(ctx, imageTag, types.ImagePullOptions{})
 }
 
 func (p *engineProvider) addImageTag(ctx context.Context, existingImageTag, newImageTag string) error {
 	return p.cli.ImageTag(ctx, existingImageTag, newImageTag)
 }
 
-func (p *engineProvider) getImageByID(ctx context.Context, name string) (types.ImageInspect, error) {
-	inspect, _, err := p.cli.ImageInspectWithRaw(ctx, name)
+func (p *engineProvider) getImageByID(ctx context.Context, id string) (types.ImageInspect, error) {
+	inspect, _, err := p.cli.ImageInspectWithRaw(ctx, id)
 
 	return inspect, err
 }
@@ -138,6 +138,14 @@ func (p *engineProvider) createContainer(ctx context.Context, config *container.
 
 func (p *engineProvider) startContainer(ctx context.Context, id string) error {
 	return p.cli.ContainerStart(ctx, id, types.ContainerStartOptions{})
+}
+
+func (p *engineProvider) pauseContainer(ctx context.Context, id string) error {
+	return p.cli.ContainerPause(ctx, id)
+}
+
+func (p *engineProvider) unpauseContainer(ctx context.Context, id string) error {
+	return p.cli.ContainerUnpause(ctx, id)
 }
 
 // exec executes the given command in the container and attaches to it.

--- a/internal/qrunner/dockerengine/gc.go
+++ b/internal/qrunner/dockerengine/gc.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
-const PausedHardDeadline = 24 * time.Hour
+const PausedContainersMaxTTL = 24 * time.Hour
 
 type garbageCollector struct {
 	ctx context.Context
@@ -134,7 +134,7 @@ func (g *garbageCollector) collectContainers() (count uint, spaceReclaimed uint6
 			continue
 		}
 
-		if c.Status == "paused" && time.Since(createdAt) < PausedHardDeadline {
+		if c.State == "paused" && time.Since(createdAt) < PausedContainersMaxTTL {
 			continue
 		}
 

--- a/internal/qrunner/dockerengine/gc.go
+++ b/internal/qrunner/dockerengine/gc.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
+const PausedHardDeadline = 24 * time.Hour
+
 type garbageCollector struct {
 	ctx context.Context
 
@@ -126,8 +128,13 @@ func (g *garbageCollector) collectContainers() (count uint, spaceReclaimed uint6
 	}
 
 	for _, c := range containers {
-		deadline := time.Unix(c.Created, 0).Add(*g.cfg.ContainerTTL)
+		createdAt := time.Unix(c.Created, 0)
+		deadline := createdAt.Add(*g.cfg.ContainerTTL)
 		if time.Now().Before(deadline) {
+			continue
+		}
+
+		if c.Status == "paused" && time.Since(createdAt) < PausedHardDeadline {
 			continue
 		}
 

--- a/internal/qrunner/dockerengine/prewarmer.go
+++ b/internal/qrunner/dockerengine/prewarmer.go
@@ -111,19 +111,19 @@ func (p *prewarmer) Stop(shutdownCtx context.Context) {
 
 // extractNextRequest extracts the next request and
 // the number of requests in the queue, waiting to be processed.
-func (p *prewarmer) extractNextRequest() (requestState, int) {
+func (p *prewarmer) extractNextRequest() (request requestState, count int) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	cnt := len(p.latestRequestsQueue)
-	if cnt == 0 {
+	count = len(p.latestRequestsQueue)
+	if count == 0 {
 		return requestState{}, 0
 	}
 
-	req := p.latestRequestsQueue[0]
+	request = p.latestRequestsQueue[0]
 	p.latestRequestsQueue = p.latestRequestsQueue[1:]
 
-	return req, cnt
+	return request, count
 }
 
 func (p *prewarmer) runContainer(request *requestState) error {

--- a/internal/qrunner/dockerengine/prewarmer.go
+++ b/internal/qrunner/dockerengine/prewarmer.go
@@ -1,0 +1,272 @@
+package dockerengine
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+type containerRunner interface {
+	createContainer(ctx context.Context, state *requestState) error
+}
+
+type prewarmer struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	logger zerolog.Logger
+
+	runner containerRunner
+	engine *engineProvider
+
+	lock sync.Mutex
+
+	containers          map[string]*containerState
+	latestRequestsQueue []requestState
+	signals             chan struct{}
+
+	maxWarmContainers uint
+}
+
+func newPrewarmer(ctx context.Context, logger zerolog.Logger, runner containerRunner, engine *engineProvider, maxWarmContainers uint) *prewarmer {
+	ctx, cancel := context.WithCancel(ctx)
+
+	return &prewarmer{
+		ctx:               ctx,
+		cancel:            cancel,
+		logger:            logger,
+		runner:            runner,
+		engine:            engine,
+		containers:        make(map[string]*containerState),
+		signals:           make(chan struct{}, 1),
+		maxWarmContainers: maxWarmContainers,
+	}
+}
+
+func (p *prewarmer) notify() {
+	select {
+	case p.signals <- struct{}{}:
+	default:
+	}
+}
+
+func (p *prewarmer) Start() error {
+	p.logger.Info().Msg("prewarmer has been started")
+
+	for {
+		select {
+		case <-p.ctx.Done():
+			return nil
+
+		case <-p.signals:
+		}
+
+		req, count := p.extractNextRequest()
+		if count == 0 {
+			continue
+		}
+
+		err := p.runContainer(&req)
+		if err != nil {
+			p.logger.Err(err).Str("image", req.imageFQN).Msg("failed to start a prewarmed container")
+		}
+
+		// If there are some unprocessed images, they will be processed in
+		// the next loop iteration.
+		// Images are processed one by one to provide better actualization
+		if count > 1 {
+			p.notify()
+		}
+	}
+}
+
+func (p *prewarmer) Stop(shutdownCtx context.Context) {
+	p.cancel()
+
+	// Release allocated resources: remove all prewarmed containers.
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.logger.Info().Int("count", len(p.containers)).Msg("start removing prewarmed containers")
+
+	for _, c := range p.containers {
+		err := p.engine.removeContainer(shutdownCtx, c.id, true)
+		if err != nil {
+			p.logger.Err(err).Str("container_id", c.id).Msg("failed to remove container")
+		}
+	}
+
+	p.containers = make(map[string]*containerState)
+
+	p.logger.Info().Msg("prewarmer has been stopped")
+}
+
+// extractNextRequest extracts the next request and
+// the number of requests in the queue, waiting to be processed.
+func (p *prewarmer) extractNextRequest() (requestState, int) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	cnt := len(p.latestRequestsQueue)
+	if cnt == 0 {
+		return requestState{}, 0
+	}
+
+	req := p.latestRequestsQueue[0]
+	p.latestRequestsQueue = p.latestRequestsQueue[1:]
+
+	return req, cnt
+}
+
+func (p *prewarmer) runContainer(request *requestState) error {
+	state := requestState{
+		runID:    "PREWARMING",
+		query:    " ",
+		version:  request.version,
+		imageTag: request.imageTag,
+		imageFQN: request.imageFQN,
+	}
+	err := p.runner.createContainer(p.ctx, &state)
+	if err != nil {
+		return fmt.Errorf("failed to create a new container: %w", err)
+	}
+
+	p.logger.Info().Str("id", state.containerID).Str("image", state.imageFQN).Msg("a new prewarmed container has been created")
+
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	_, found := p.containers[request.imageFQN]
+	if found {
+		return errors.New("container for that image already exists")
+	}
+
+	container := &containerState{
+		id:        state.containerID,
+		imageFQN:  state.imageFQN,
+		createdAt: time.Now(),
+		status:    statusRunning,
+	}
+	p.containers[request.imageFQN] = container
+
+	// If the number of prewarmed containers exceeds the limit,
+	// delete the oldest.
+	if len(p.containers) > int(p.maxWarmContainers) {
+		oldestImage := container.imageFQN
+		oldestDate := container.createdAt
+		for fqn, c := range p.containers {
+			if c.createdAt.Before(oldestDate) {
+				oldestImage = fqn
+				oldestDate = c.createdAt
+			}
+		}
+
+		oldestContainer := p.containers[oldestImage]
+		delete(p.containers, oldestImage)
+
+		go func() {
+			err := p.engine.removeContainer(p.ctx, oldestContainer.id, true)
+			if err != nil {
+				p.logger.Err(err).Str("container_id", oldestContainer.id).Msg("failed to remove container")
+			}
+		}()
+	}
+
+	// Pause container after some time to allow its bootstrap.
+	go func() {
+		release := container.acquireLock()
+		defer release()
+
+		if container.status != statusRunning {
+			return
+		}
+
+		err := p.engine.pauseContainer(p.ctx, container.id)
+		if err != nil {
+			p.logger.Err(err).Str("container_id", container.id).Msg("failed to pause container")
+			return
+		}
+
+		container.setStatus(statusPaused)
+
+		p.logger.Info().Str("id", container.id).Str("image", container.imageFQN).Msg("container has been paused")
+	}()
+
+	return nil
+}
+
+// PushNewRequest should be called when a new request comes.
+// It remembers the request and signals the background worker to process this new images.
+func (p *prewarmer) PushNewRequest(request requestState) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	// If there is such an image in the waiting queue, skip it.
+	for _, r := range p.latestRequestsQueue {
+		if r.imageFQN == request.imageFQN {
+			return
+		}
+	}
+
+	// Add a new item to the queue and trim the prefix if necessary.
+	p.latestRequestsQueue = append(p.latestRequestsQueue, request)
+	if len(p.latestRequestsQueue) >= int(p.maxWarmContainers) && len(p.latestRequestsQueue) > 0 {
+		p.latestRequestsQueue = p.latestRequestsQueue[1:]
+	}
+
+	p.notify()
+}
+
+// Fetch returns id of a warm container if it exists.
+// It is safe to exec in the returned container immediately
+// (containers are unpaused when they are fetched).
+func (p *prewarmer) Fetch(imageFQN string) (containerID string, found bool, err error) {
+	c := p.extractContainer(imageFQN)
+	if c == nil {
+		return "", false, nil
+	}
+
+	err = p.unpauseIfNecessary(c)
+	if err != nil {
+		return "", false, err
+	}
+
+	return c.id, true, nil
+}
+
+func (p *prewarmer) extractContainer(imageFQN string) (container *containerState) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	container, found := p.containers[imageFQN]
+	if !found {
+		return nil
+	}
+
+	delete(p.containers, imageFQN)
+
+	return container
+}
+
+func (p *prewarmer) unpauseIfNecessary(c *containerState) error {
+	release := c.acquireLock()
+	defer release()
+
+	if c.status == statusRunning {
+		return nil
+	}
+
+	err := p.engine.unpauseContainer(p.ctx, c.id)
+	if err != nil {
+		return fmt.Errorf("unpause failed: %w", err)
+	}
+
+	p.logger.Info().Str("id", c.id).Str("image", c.imageFQN).Msg("container has been unpaused")
+
+	c.setStatus(statusFetched)
+
+	return nil
+}

--- a/internal/qrunner/dockerengine/prewarmer.go
+++ b/internal/qrunner/dockerengine/prewarmer.go
@@ -1,6 +1,7 @@
 package dockerengine
 
 import (
+	"clickhouse-playground/internal/metrics"
 	"context"
 	"fmt"
 	"sync"
@@ -18,6 +19,7 @@ type prewarmer struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	logger zerolog.Logger
+	metr   *metrics.PrewarmerExporter
 
 	runner containerRunner
 	engine *engineProvider
@@ -38,6 +40,7 @@ func newPrewarmer(ctx context.Context, logger zerolog.Logger, runner containerRu
 		ctx:               ctx,
 		cancel:            cancel,
 		logger:            logger,
+		metr:              metrics.NewPrewarmerExporter(),
 		runner:            runner,
 		engine:            engine,
 		containers:        make(map[string]*containerState),
@@ -96,6 +99,8 @@ func (p *prewarmer) Stop(shutdownCtx context.Context) {
 		err := p.engine.removeContainer(shutdownCtx, c.id, true)
 		if err != nil {
 			p.logger.Err(err).Str("container_id", c.id).Msg("failed to remove container")
+		} else {
+			p.metr.EjectContainer()
 		}
 	}
 
@@ -134,8 +139,6 @@ func (p *prewarmer) runContainer(request *requestState) error {
 		return fmt.Errorf("failed to create a new container: %w", err)
 	}
 
-	p.logger.Info().Str("id", state.containerID).Str("image", state.imageFQN).Msg("a new prewarmed container has been created")
-
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -155,24 +158,7 @@ func (p *prewarmer) runContainer(request *requestState) error {
 	// If the number of prewarmed containers exceeds the limit,
 	// delete the oldest.
 	if len(p.containers) > int(p.maxWarmContainers) {
-		oldestImage := container.imageFQN
-		oldestDate := container.createdAt
-		for fqn, c := range p.containers {
-			if c.createdAt.Before(oldestDate) {
-				oldestImage = fqn
-				oldestDate = c.createdAt
-			}
-		}
-
-		oldestContainer := p.containers[oldestImage]
-		delete(p.containers, oldestImage)
-
-		go func() {
-			err := p.engine.removeContainer(p.ctx, oldestContainer.id, true)
-			if err != nil {
-				p.logger.Err(err).Str("container_id", oldestContainer.id).Msg("failed to remove container")
-			}
-		}()
+		p.ejectContainer()
 	}
 
 	// Pause container after some time to allow its bootstrap.
@@ -192,10 +178,40 @@ func (p *prewarmer) runContainer(request *requestState) error {
 
 		container.setStatus(statusPaused)
 
-		p.logger.Info().Str("id", container.id).Str("image", container.imageFQN).Msg("container has been paused")
+		p.logger.Debug().Str("id", container.id).Str("image", container.imageFQN).Msg("container has been paused")
 	}()
 
+	p.metr.AddContainer()
+	p.logger.Debug().Str("id", container.id).Str("image", container.imageFQN).
+		Msg("a new container has been added to the prewarmed set")
+
 	return nil
+}
+
+// ejectContainer removes the oldest container to allow a new container to be created.
+func (p *prewarmer) ejectContainer() {
+	var oldestImage string
+	oldestDate := time.Now()
+	for fqn, c := range p.containers {
+		if c.createdAt.Before(oldestDate) {
+			oldestImage = fqn
+			oldestDate = c.createdAt
+		}
+	}
+
+	container := p.containers[oldestImage]
+	delete(p.containers, oldestImage)
+
+	p.metr.EjectContainer()
+	p.logger.Debug().Str("id", container.id).Str("image", container.imageFQN).
+		Msg("a container has been ejected from the prewarmed set")
+
+	go func() {
+		err := p.engine.removeContainer(p.ctx, container.id, true)
+		if err != nil {
+			p.logger.Err(err).Str("container_id", container.id).Msg("failed to remove container")
+		}
+	}()
 }
 
 // PushNewRequest should be called when a new request comes.
@@ -226,6 +242,9 @@ func (p *prewarmer) PushNewRequest(request requestState) {
 func (p *prewarmer) Fetch(imageFQN string) (containerID string, found bool, err error) {
 	c := p.extractContainer(imageFQN)
 	if c == nil {
+		p.metr.FetchMiss()
+		p.logger.Debug().Str("image", imageFQN).Msg("prewarmer cache miss")
+
 		return "", false, nil
 	}
 
@@ -233,6 +252,9 @@ func (p *prewarmer) Fetch(imageFQN string) (containerID string, found bool, err 
 	if err != nil {
 		return "", false, err
 	}
+
+	p.metr.FetchHit()
+	p.logger.Debug().Str("id", c.id).Str("image", c.imageFQN).Msg("prewarmer cache hit")
 
 	return c.id, true, nil
 }
@@ -247,6 +269,10 @@ func (p *prewarmer) extractContainer(imageFQN string) (container *containerState
 	}
 
 	delete(p.containers, imageFQN)
+
+	p.metr.FetchContainer()
+	p.logger.Debug().Str("id", container.id).Str("image", container.imageFQN).
+		Msg("a container has been fetched from the prewarmed set")
 
 	return container
 }
@@ -264,7 +290,7 @@ func (p *prewarmer) unpauseIfNecessary(c *containerState) error {
 		return fmt.Errorf("unpause failed: %w", err)
 	}
 
-	p.logger.Info().Str("id", c.id).Str("image", c.imageFQN).Msg("container has been unpaused")
+	p.logger.Debug().Str("id", c.id).Str("image", c.imageFQN).Msg("container has been unpaused")
 
 	c.setStatus(statusFetched)
 

--- a/internal/qrunner/dockerengine/state.go
+++ b/internal/qrunner/dockerengine/state.go
@@ -7,6 +7,11 @@ type requestState struct {
 	version string
 	query   string
 
-	chpImageName string
-	containerID  string
+	// <repository>:<version>
+	imageTag string
+
+	// a unique name that refers the image
+	imageFQN string
+
+	containerID string
 }

--- a/internal/qrunner/ec2/runner.go
+++ b/internal/qrunner/ec2/runner.go
@@ -66,7 +66,7 @@ func (r *Runner) Start() error {
 	return nil
 }
 
-func (r *Runner) Stop() error {
+func (r *Runner) Stop(_ context.Context) error {
 	r.cancel()
 
 	return nil

--- a/internal/qrunner/runner.go
+++ b/internal/qrunner/runner.go
@@ -17,5 +17,5 @@ type Runner interface {
 	Start() error
 
 	// Stop stops background tasks and waits for their finish.
-	Stop() error
+	Stop(shutdownCtx context.Context) error
 }

--- a/internal/qrunner/stubrunner/runner.go
+++ b/internal/qrunner/stubrunner/runner.go
@@ -48,7 +48,7 @@ func (r *Runner) Start() error {
 	return nil
 }
 
-func (r *Runner) Stop() error {
+func (r *Runner) Stop(_ context.Context) error {
 	return nil
 }
 


### PR DESCRIPTION
A new component is presented: prewarmer. It starts containers in advance to optimize the latency and try to escape cold starts.

Inspiration for the prewarming policy is taken from the following papers:
- Panda, A. and Sarangi, S.R., 2023. FaaSched: A Jitter-Aware Serverless Scheduler. arXiv preprint arXiv:2303.06473.
- Kaffes, K., Yadwadkar, N.J. and Kozyrakis, C., 2021. Practical scheduling for real-world serverless computing. arXiv preprint arXiv:2111.07226.
- Fuerst, A. and Sharma, P., 2021, April. FaasCache: keeping serverless computing alive with greedy-dual caching. In Proceedings of the 26th ACM International Conference on Architectural Support for Programming Languages and Operating Systems (pp. 386-400).
- Fuerst, A. and Sharma, P., 2022, June. Locality-aware Load-Balancing For Serverless Clusters. In Proceedings of the 31st International Symposium on High-Performance Parallel and Distributed Computing (pp. 227-239).