### PR TITLE
Fix formatting options condition

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -27,8 +28,16 @@ const (
 	RunnerTypeDockerEngine RunnerType = "DOCKER_ENGINE"
 )
 
+type LogFormat string
+
+const (
+	PrettyLogFormat LogFormat = "pretty"
+	JSONLogFormat   LogFormat = "json"
+)
+
 type Config struct {
-	LogLevel string `mapstructure:"log_level"`
+	LogLevel  string    `mapstructure:"log_level"`
+	LogFormat LogFormat `mapstructure:"log_format"`
 
 	DockerImage DockerImage `mapstructure:"docker_image"`
 
@@ -199,6 +208,16 @@ func LoadConfig() (*Config, error) {
 func (c *Config) validate() error {
 	if c.LogLevel == "" {
 		c.LogLevel = "debug"
+	}
+
+	switch c.LogFormat {
+	case "":
+		c.LogFormat = JSONLogFormat
+
+	case JSONLogFormat, PrettyLogFormat:
+
+	default:
+		return fmt.Errorf("invalid log format (available: %s, %s)", JSONLogFormat, PrettyLogFormat)
 	}
 
 	if len(c.DockerImage.Repositories) == 0 {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -31,10 +31,6 @@ func main() {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
-	// Basic logging preparation.
-	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
-	zlog.Logger = zlog.Output(zerolog.ConsoleWriter{Out: os.Stderr})
-
 	// Initialize config.
 	config, err := LoadConfig()
 	if err != nil {
@@ -42,6 +38,11 @@ func main() {
 	}
 
 	// Initialize logger.
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnixMs
+	if config.LogFormat == PrettyLogFormat {
+		zlog.Logger = zlog.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	}
+
 	lvl, err := zerolog.ParseLevel(config.LogLevel)
 	if err != nil {
 		zlog.Fatal().Err(err).Msg("invalid log level")

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,7 +16,6 @@ import (
 	"clickhouse-playground/pkg/dockerhub"
 	api "clickhouse-playground/pkg/restapi"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconf "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -73,7 +72,7 @@ func main() {
 	tagStorage.RunBackgroundUpdate()
 
 	// Create runners and the coordinator.
-	runners := initializeRunners(ctx, config, awsConfig, tagStorage, logger)
+	runners := initializeRunners(ctx, config, tagStorage, logger)
 
 	coordinatorCfg := coordinator.Config{
 		HealthChecksEnabled:   true,
@@ -144,7 +143,7 @@ func main() {
 	}
 }
 
-func initializeRunners(ctx context.Context, config *Config, awsConfig aws.Config, tagStorage *dockertag.Cache, logger zerolog.Logger) []*coordinator.Runner {
+func initializeRunners(ctx context.Context, config *Config, tagStorage *dockertag.Cache, logger zerolog.Logger) []*coordinator.Runner {
 	var runners []*coordinator.Runner
 	for _, r := range config.Runners {
 		var runner qrunner.Runner

--- a/internal/qrunner/dockerengine/runner.go
+++ b/internal/qrunner/dockerengine/runner.go
@@ -387,7 +387,7 @@ func (r *Runner) execQuery(ctx context.Context, state *requestState) (stdout str
 	}
 
 	// Inject some format options to make output prettier.
-	if !chsemver.IsAtLeastMajor(state.version, "21") {
+	if chsemver.IsAtLeastMajor(state.version, "21") {
 		args = append(args,
 			"--output_format_pretty_color", "0",
 			"--output_format_pretty_grid_charset", "ASCII",

--- a/pkg/chsemver/semver_test.go
+++ b/pkg/chsemver/semver_test.go
@@ -1,6 +1,7 @@
 package chsemver
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,6 +41,51 @@ func TestParse(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.Input, func(t *testing.T) {
 			assert.EqualValues(t, Parse(test.Input), test.Expected)
+		})
+	}
+}
+
+func TestIsAtLeastMajor(t *testing.T) {
+	cases := []struct {
+		Version  string
+		Major    string
+		Expected bool
+	}{
+		{
+			Version:  "1",
+			Major:    "21",
+			Expected: false,
+		},
+		{
+			Version:  "1",
+			Major:    "21.1",
+			Expected: false,
+		},
+		{
+			Version:  "1.28",
+			Major:    "21",
+			Expected: false,
+		},
+		{
+			Version:  "9.11",
+			Major:    "10",
+			Expected: false,
+		},
+		{
+			Version:  "21.32",
+			Major:    "20",
+			Expected: true,
+		},
+		{
+			Version:  "21",
+			Major:    "21",
+			Expected: true,
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(fmt.Sprintf("%s >= %s?", test.Version, test.Major), func(t *testing.T) {
+			assert.EqualValues(t, IsAtLeastMajor(test.Version, test.Major), test.Expected)
 		})
 	}
 }


### PR DESCRIPTION
Minor patch:
- Format options are now applied only for ClickHouse >= 21
- Default logs format is JSON