### PR TITLE
Fix fetching docker image tags

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -63,7 +63,13 @@ type Limits struct {
 	MaxOutputLength uint64 `mapstructure:"max_output_length"`
 }
 
+type DockerAuth struct {
+	Identifier string `mapstructure:"identifier"`
+	Secret     string `mapstructure:"secret"`
+}
+
 type DockerImage struct {
+	Auth                DockerAuth    `mapstructure:"auth"`
 	Repositories        []string      `mapstructure:"repositories"`
 	OS                  string        `mapstructure:"os"`
 	Architecture        string        `mapstructure:"architecture"`
@@ -220,6 +226,12 @@ func (c *Config) validate() error {
 		return fmt.Errorf("invalid log format (available: %s, %s)", JSONLogFormat, PrettyLogFormat)
 	}
 
+	if c.DockerImage.Auth.Identifier == "" {
+		return errors.New("docker_image.auth.identifier is required, see https://docs.docker.com/reference/api/hub/latest/#tag/authentication-api/operation/AuthCreateAccessToken")
+	}
+	if c.DockerImage.Auth.Secret == "" {
+		return errors.New("docker_image.auth.secret is required, see https://docs.docker.com/reference/api/hub/latest/#tag/authentication-api/operation/AuthCreateAccessToken")
+	}
 	if len(c.DockerImage.Repositories) == 0 {
 		return errors.New("docker_image.repositories must be non-empty")
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -68,7 +68,7 @@ func main() {
 
 	// Initialize storages.
 	dynamodbClient := dynamodb.NewFromConfig(awsConfig)
-	dockerhubCli := dockerhub.NewClient(dockerhub.DockerHubURL, dockerhub.DefaultMaxRPS)
+	dockerhubCli := dockerhub.NewClient(dockerhub.DockerHubURL, dockerhub.DefaultMaxRPS, dockerhub.Auth(config.DockerImage.Auth))
 	tagStorage := dockertag.NewCache(ctx, dockertag.Config{
 		Repositories:   config.DockerImage.Repositories,
 		OS:             config.DockerImage.OS,

--- a/config.yml
+++ b/config.yml
@@ -6,6 +6,13 @@ log_level: info
 
 # ClickHouse Docker image configuration.
 docker_image:
+  auth:
+    # Docker Hub Auth details are required to list all docker image tags.
+    # See more details here: https://github.com/docker/hub-feedback/issues/2484
+    # Reference on issuing a token:
+    # https://docs.docker.com/reference/api/hub/latest/#tag/authentication-api/operation/AuthCreateAccessToken
+    identifier: "" # Docker Hub Username
+    secret: "" # Docker Hub Personal Token
   repositories:
     - clickhouse/clickhouse-server
     - yandex/clickhouse-server

--- a/deploy/config.yml
+++ b/deploy/config.yml
@@ -6,6 +6,13 @@ log_level: info
 
 # ClickHouse Docker image configuration.
 docker_image:
+  auth:
+    # Docker Hub Auth details are required to list all docker image tags.
+    # See more details here: https://github.com/docker/hub-feedback/issues/2484
+    # Reference on issuing a token:
+    # https://docs.docker.com/reference/api/hub/latest/#tag/authentication-api/operation/AuthCreateAccessToken
+    identifier: "" # Docker Hub Username
+    secret: "" # Docker Hub Personal Token
   repositories:
     - clickhouse/clickhouse-server
     - yandex/clickhouse-server

--- a/pkg/dockerhub/client.go
+++ b/pkg/dockerhub/client.go
@@ -1,6 +1,7 @@
 package dockerhub
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,16 +15,25 @@ import (
 const DockerHubURL = "https://hub.docker.com/v2"
 const DefaultMaxRPS = 5
 
+// Auth holds information required to obtain an access token:
+// https://docs.docker.com/reference/api/hub/latest/#tag/authentication-api/operation/AuthCreateAccessToken
+type Auth struct {
+	Identifier string `json:"identifier"`
+	Secret     string `json:"secret"`
+}
+
 type Client struct {
 	apiURL string
+	auth   Auth
 	rl     ratelimit.Limiter
 
 	cli *http.Client
 }
 
-func NewClient(apiURL string, maxRPS int, httpCli ...*http.Client) *Client {
+func NewClient(apiURL string, maxRPS int, auth Auth, httpCli ...*http.Client) *Client {
 	c := &Client{
 		apiURL: apiURL,
+		auth:   auth,
 		rl:     ratelimit.New(maxRPS),
 		cli:    http.DefaultClient,
 	}
@@ -34,13 +44,43 @@ func NewClient(apiURL string, maxRPS int, httpCli ...*http.Client) *Client {
 	return c
 }
 
+func (c *Client) getAccessToken() (string, error) {
+	url := fmt.Sprintf("%s/auth/token", c.apiURL)
+
+	request, err := json.Marshal(c.auth)
+	if err != nil {
+		return "", fmt.Errorf("json marshal failed: %w", err)
+	}
+
+	resp, err := c.cli.Post(url, "application/json", bytes.NewReader(request))
+	if err != nil {
+		return "", fmt.Errorf("http request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	response := struct {
+		AccessToken string `json:"access_token"`
+	}{}
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		return "", fmt.Errorf("json decode access token response: %w", err)
+	}
+
+	return response.AccessToken, nil
+}
+
 // GetTags fetches tags of the given image.
 func (c *Client) GetTags(repository string) ([]ImageTag, error) {
-	nextURL := fmt.Sprintf("%s/repositories/%s/tags/", c.apiURL, repository)
+	token, err := c.getAccessToken()
+	if err != nil {
+		return nil, fmt.Errorf("failed to acquire an access token: %w", err)
+	}
+
+	nextURL := fmt.Sprintf("%s/repositories/%s/tags?page_size=100", c.apiURL, repository)
 
 	var tags []ImageTag
 	for {
-		resp, err := c.getTags(nextURL)
+		resp, err := c.getTags(nextURL, token)
 		if err != nil {
 			return nil, err
 		}
@@ -56,10 +96,17 @@ func (c *Client) GetTags(repository string) ([]ImageTag, error) {
 	return tags, nil
 }
 
-func (c *Client) getTags(url string) (*GetImageTagsResponse, error) { // nolint
+func (c *Client) getTags(url string, token string) (*GetImageTagsResponse, error) { // nolint
 	c.rl.Take()
 
-	resp, err := c.cli.Get(url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create http request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.cli.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "request failed")
 	}
@@ -71,6 +118,7 @@ func (c *Client) getTags(url string) (*GetImageTagsResponse, error) { // nolint
 	}
 
 	response := new(GetImageTagsResponse)
+
 	err = json.Unmarshal(body, response)
 	if err != nil {
 		zlog.Error().Err(err).Str("url", url).Str("body", string(body)).Msg("failed to fetch image tags")


### PR DESCRIPTION
Fixes #53 

New required config fields were introduced:
```yaml
docker_image:
  auth:
    # Docker Hub Auth details are required to list all docker image tags.
    # See more details here: https://github.com/docker/hub-feedback/issues/2484
    # Reference on issuing a token:
    # https://docs.docker.com/reference/api/hub/latest/#tag/authentication-api/operation/AuthCreateAccessToken
    identifier: "" # Docker Hub Username
    secret: "" # Docker Hub Personal Token
```