### PR TITLE
Improve docker api resilience

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -79,6 +79,7 @@ type DockerImage struct {
 type API struct {
 	ListeningAddress string        `mapstructure:"address"`
 	ServerTimeout    time.Duration `mapstructure:"server_timeout"`
+	CacheDisabled    bool          `mapstructure:"cache_disabled"`
 }
 
 type AWS struct {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -102,6 +102,7 @@ func main() {
 		TagStorage:      tagStorage,
 		RunRepo:         runRepo,
 		Timeout:         config.API.ServerTimeout,
+		CacheDisabled:   config.API.CacheDisabled,
 		MaxQueryLength:  lim.MaxOutputLength,
 		MaxOutputLength: lim.MaxOutputLength,
 	})

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -68,7 +68,7 @@ func main() {
 
 	// Initialize storages.
 	dynamodbClient := dynamodb.NewFromConfig(awsConfig)
-	dockerhubCli := dockerhub.NewClient(dockerhub.DockerHubURL, dockerhub.DefaultMaxRPS, dockerhub.Auth(config.DockerImage.Auth))
+	dockerhubCli := dockerhub.NewClient(logger, dockerhub.DockerHubURL, dockerhub.DefaultMaxRPS, dockerhub.Auth(config.DockerImage.Auth))
 	tagStorage := dockertag.NewCache(ctx, dockertag.Config{
 		Repositories:   config.DockerImage.Repositories,
 		OS:             config.DockerImage.OS,

--- a/config.yml
+++ b/config.yml
@@ -31,6 +31,10 @@ api:
   # [OPTIONAL] Request processing timeout. Default: 60s.
   server_timeout: 60s
 
+  # [OPTIONAL] Whether to send HTTP headers preventing upstream proxies to cache responses.
+  # Default: false.
+  cache_disabled: false
+
 # You can set some limits to prevent budget waste on storage and etc.
 limits:
   # If the length of a user's query exceeds this limit, the request is aborted.

--- a/deploy/config.yml
+++ b/deploy/config.yml
@@ -31,6 +31,10 @@ api:
   # [OPTIONAL] Request processing timeout. Default: 60s.
   server_timeout: 60s
 
+  # [OPTIONAL] Whether to send HTTP headers preventing upstream proxies to cache responses.
+  # Default: false.
+  cache_disabled: false
+
 # You can set some limits to prevent budget waste on storage and etc.
 limits:
   # If the length of a user's query exceeds this limit, the request is aborted.

--- a/pkg/restapi/router.go
+++ b/pkg/restapi/router.go
@@ -21,7 +21,8 @@ type RouterOpts struct {
 	TagStorage TagStorage
 	RunRepo    queryrun.Repository
 
-	Timeout time.Duration
+	Timeout       time.Duration
+	CacheDisabled bool
 
 	MaxQueryLength  uint64
 	MaxOutputLength uint64
@@ -40,6 +41,9 @@ func NewRouter(opts RouterOpts) http.Handler {
 	r.Use(middleware.Recoverer)
 
 	r.Use(middleware.Timeout(opts.Timeout))
+	if opts.CacheDisabled {
+		r.Use(middleware.NoCache)
+	}
 
 	r.Use(cors.Handler(cors.Options{
 		// AllowedOrigins:   []string{"https://foo.com"}, // Use this to allow specific origin hosts


### PR DESCRIPTION
Address some of the ideas mentioned in #53:
- More logs to simplify docker hub API problems investigation
- Ability to disable cloudflare cache