### PR TITLE
Remove explicit ASCII charset for table formatting

### DIFF
--- a/internal/dbsettings/runsettings/clickhouse_settings.go
+++ b/internal/dbsettings/runsettings/clickhouse_settings.go
@@ -29,7 +29,6 @@ func (cs *ClickHouseSettings) FormatArgs(version string, defaultOutputFormat str
 
 		result = append(result,
 			"--output_format_pretty_color", "0",
-			"--output_format_pretty_grid_charset", "ASCII",
 			"--format", outputFormat)
 	}
 

--- a/internal/qrunner/dockerengine/runner_test.go
+++ b/internal/qrunner/dockerengine/runner_test.go
@@ -77,7 +77,7 @@ func TestCustomSettings(t *testing.T) {
 			database:       "clickhouse",
 			version:        "21",
 			query:          "SELECT 1",
-			expectedOutput: "+-1-+\n| 1 |\n+---+\n",
+			expectedOutput: "┌─1─┐\n│ 1 │\n└───┘\n",
 			runSettings:    &runsettings.ClickHouseSettings{OutputFormat: "PrettyCompactMonoBlock"},
 		},
 		{


### PR DESCRIPTION
Let ClickHouse use its default UTF-8 charset for pretty table output, which renders nicer Unicode box-drawing characters.