### PR TITLE
Add debug/sanitizer build variants

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -83,6 +83,8 @@ type DockerImage struct {
 type Builds struct {
 	Enabled bool `mapstructure:"enabled"`
 
+	// TODO: Use *string for optional parameters.
+
 	// ReportBaseURL is the S3 location hosting ClickHouse CI (praktika) report JSON files.
 	ReportBaseURL string `mapstructure:"report_base_url"`
 	// GitHubAPIURL is used to resolve a version's git tag to a commit sha.

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -74,6 +74,30 @@ type DockerImage struct {
 	OS                  string        `mapstructure:"os"`
 	Architecture        string        `mapstructure:"architecture"`
 	CacheExpirationTime time.Duration `mapstructure:"image_tags_cache_expiration_time"`
+
+	Builds Builds `mapstructure:"builds"`
+}
+
+// Builds configures local image builds for non-release (debug/sanitizer) build types.
+// When disabled, only release builds (pulled from Docker Hub) are available.
+type Builds struct {
+	Enabled bool `mapstructure:"enabled"`
+
+	// ReportBaseURL is the S3 location hosting ClickHouse CI (praktika) report JSON files.
+	ReportBaseURL string `mapstructure:"report_base_url"`
+	// GitHubAPIURL is used to resolve a version's git tag to a commit sha.
+	GitHubAPIURL string `mapstructure:"github_api_url"`
+	// Repository is the ClickHouse GitHub repository ("owner/name").
+	Repository string `mapstructure:"repository"`
+	// GitHubToken is optional; it raises the GitHub API rate limit when set.
+	GitHubToken string `mapstructure:"github_token"`
+
+	// ResolveCacheTTL bounds how long resolved artifact URLs are cached.
+	ResolveCacheTTL time.Duration `mapstructure:"resolve_cache_ttl"`
+	// Timeout bounds a single image build.
+	Timeout time.Duration `mapstructure:"timeout"`
+	// MaxConcurrent limits concurrent image builds. 0 means unlimited.
+	MaxConcurrent uint `mapstructure:"max_concurrent"`
 }
 
 type API struct {
@@ -86,6 +110,10 @@ type AWS struct {
 	AccessKeyID     string `mapstructure:"access_key_id"`
 	SecretAccessKey string `mapstructure:"secret_access_key"`
 	Region          string `mapstructure:"region"`
+
+	// EndpointURL overrides the DynamoDB endpoint. Leave empty for real AWS; set it to point
+	// at a local DynamoDB (e.g. http://dynamodb-local:8000) for development.
+	EndpointURL string `mapstructure:"endpoint_url"`
 
 	QueryRunsTableName string `mapstructure:"query_runs_table"`
 }
@@ -227,11 +255,14 @@ func (c *Config) validate() error {
 		return fmt.Errorf("invalid log format (available: %s, %s)", JSONLogFormat, PrettyLogFormat)
 	}
 
-	if c.DockerImage.Auth.Identifier == "" {
-		return errors.New("docker_image.auth.identifier is required, see https://docs.docker.com/reference/api/hub/latest/#tag/authentication-api/operation/AuthCreateAccessToken")
+	// Docker Hub credentials are optional: when omitted, tags are listed anonymously (with
+	// stricter rate limits). Provide them to raise the rate limit, see
+	// https://docs.docker.com/reference/api/hub/latest/#tag/authentication-api/operation/AuthCreateAccessToken
+	if (c.DockerImage.Auth.Identifier == "") != (c.DockerImage.Auth.Secret == "") {
+		return errors.New("docker_image.auth.identifier and docker_image.auth.secret must be set together")
 	}
-	if c.DockerImage.Auth.Secret == "" {
-		return errors.New("docker_image.auth.secret is required, see https://docs.docker.com/reference/api/hub/latest/#tag/authentication-api/operation/AuthCreateAccessToken")
+	if c.DockerImage.Auth.Identifier == "" {
+		zlog.Warn().Msg("docker_image.auth is empty; listing Docker Hub tags anonymously (rate limited)")
 	}
 	if len(c.DockerImage.Repositories) == 0 {
 		return errors.New("docker_image.repositories must be non-empty")

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -8,14 +8,17 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/lodthe/clickhouse-playground/internal/cibuild"
 	"github.com/lodthe/clickhouse-playground/internal/dockertag"
 	"github.com/lodthe/clickhouse-playground/internal/qrunner"
 	"github.com/lodthe/clickhouse-playground/internal/qrunner/coordinator"
 	"github.com/lodthe/clickhouse-playground/internal/qrunner/dockerengine"
 	"github.com/lodthe/clickhouse-playground/internal/queryrun"
+	"github.com/lodthe/clickhouse-playground/pkg/clickhousebuilds"
 	"github.com/lodthe/clickhouse-playground/pkg/dockerhub"
 	api "github.com/lodthe/clickhouse-playground/pkg/restapi"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconf "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -67,7 +70,11 @@ func main() {
 	}
 
 	// Initialize storages.
-	dynamodbClient := dynamodb.NewFromConfig(awsConfig)
+	dynamodbClient := dynamodb.NewFromConfig(awsConfig, func(o *dynamodb.Options) {
+		if config.AWS.EndpointURL != "" {
+			o.BaseEndpoint = aws.String(config.AWS.EndpointURL)
+		}
+	})
 	dockerhubCli := dockerhub.NewClient(logger, dockerhub.DockerHubURL, dockerhub.DefaultMaxRPS, dockerhub.Auth(config.DockerImage.Auth))
 	tagStorage := dockertag.NewCache(ctx, dockertag.Config{
 		Repositories:   config.DockerImage.Repositories,
@@ -75,10 +82,19 @@ func main() {
 		Architecture:   config.DockerImage.Architecture,
 		ExpirationTime: config.DockerImage.CacheExpirationTime,
 	}, logger, dockerhubCli)
+
+	// Load tags synchronously first so the API does not reject valid versions during the
+	// initial fetch. Best-effort: on failure the background updater will retry.
+	if err := tagStorage.Update(); err != nil {
+		zlog.Warn().Err(err).Msg("initial docker tag load failed; will retry in background")
+	}
 	tagStorage.RunBackgroundUpdate()
 
+	// Build the CI artifact resolver used for local debug/sanitizer image builds.
+	resolver := newBuildResolver(config, logger)
+
 	// Create runners and the coordinator.
-	runners := initializeRunners(ctx, config, tagStorage, logger)
+	runners := initializeRunners(ctx, config, tagStorage, resolver, logger)
 
 	coordinatorCfg := coordinator.Config{
 		HealthChecksEnabled:   true,
@@ -99,6 +115,7 @@ func main() {
 	router := api.NewRouter(api.RouterOpts{
 		Logger:          logger,
 		Runner:          coord,
+		Preparer:        coord,
 		TagStorage:      tagStorage,
 		RunRepo:         runRepo,
 		Timeout:         config.API.ServerTimeout,
@@ -158,7 +175,25 @@ func main() {
 	}
 }
 
-func initializeRunners(ctx context.Context, config *Config, tagStorage *dockertag.Cache, logger zerolog.Logger) []*coordinator.Runner {
+// newBuildResolver constructs the CI artifact resolver used for local image builds.
+// It returns nil when local builds are disabled.
+func newBuildResolver(config *Config, logger zerolog.Logger) cibuild.Resolver {
+	b := config.DockerImage.Builds
+	if !b.Enabled {
+		return nil
+	}
+
+	cli := clickhousebuilds.NewClient(logger, clickhousebuilds.Config{
+		ReportBaseURL: b.ReportBaseURL,
+		GitHubAPIURL:  b.GitHubAPIURL,
+		Repository:    b.Repository,
+		GitHubToken:   b.GitHubToken,
+	})
+
+	return cibuild.NewResolver(logger, cli, cibuild.Config{CacheTTL: b.ResolveCacheTTL})
+}
+
+func initializeRunners(ctx context.Context, config *Config, tagStorage *dockertag.Cache, resolver cibuild.Resolver, logger zerolog.Logger) []*coordinator.Runner {
 	var runners []*coordinator.Runner
 	for _, r := range config.Runners {
 		var runner qrunner.Runner
@@ -195,8 +230,15 @@ func initializeRunners(ctx context.Context, config *Config, tagStorage *dockerta
 				rcfg.MaxWarmContainers = *r.DockerEngine.Prewarm.MaxWarmContainers
 			}
 
+			builds := config.DockerImage.Builds
+			rcfg.Builds = dockerengine.BuildSettings{
+				Enabled:       builds.Enabled,
+				Timeout:       builds.Timeout,
+				MaxConcurrent: builds.MaxConcurrent,
+			}
+
 			var err error
-			runner, err = dockerengine.New(ctx, logger, r.Name, rcfg, tagStorage)
+			runner, err = dockerengine.New(ctx, logger, r.Name, rcfg, tagStorage, resolver)
 			if err != nil {
 				zlog.Fatal().Err(err).Msg("failed to create docker engine runner")
 			}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -83,11 +83,8 @@ func main() {
 		ExpirationTime: config.DockerImage.CacheExpirationTime,
 	}, logger, dockerhubCli)
 
-	// Load tags synchronously first so the API does not reject valid versions during the
-	// initial fetch. Best-effort: on failure the background updater will retry.
-	if err := tagStorage.Update(); err != nil {
-		zlog.Warn().Err(err).Msg("initial docker tag load failed; will retry in background")
-	}
+	// Load tags asynchronously so Docker Hub outages / API changes do not block read endpoints,
+	// which do not require a complete tag list.
 	tagStorage.RunBackgroundUpdate()
 
 	// Build the CI artifact resolver used for local debug/sanitizer image builds.

--- a/config.yml
+++ b/config.yml
@@ -23,6 +23,39 @@ docker_image:
   # [OPTIONAL] How often available image tags will be fetched from dockerhub.
   image_tags_cache_expiration_time: 3m
 
+  # [OPTIONAL] Local builds of non-release ClickHouse images (debug, asan, tsan, msan, ubsan).
+  # Release images are pulled from Docker Hub; the other build types are not published there,
+  # so when enabled the backend builds them locally from the .deb packages produced by
+  # ClickHouse CI on release branches, caches the resulting image, and runs it.
+  # These builds are large and slow (minutes), so they are prepared asynchronously via
+  # POST /api/images/prepare and polled via GET /api/images/status before running a query.
+  # Default: disabled.
+  builds:
+    enabled: false
+
+    # [OPTIONAL] S3 location hosting ClickHouse CI (praktika) report JSON files.
+    # Default: https://s3.amazonaws.com/clickhouse-test-reports
+    report_base_url: https://s3.amazonaws.com/clickhouse-test-reports
+
+    # [OPTIONAL] GitHub API base URL, used to resolve a version's "-stable" git tag to a sha.
+    # Default: https://api.github.com
+    github_api_url: https://api.github.com
+
+    # [OPTIONAL] ClickHouse GitHub repository ("owner/name"). Default: ClickHouse/ClickHouse.
+    repository: ClickHouse/ClickHouse
+
+    # [OPTIONAL] GitHub token. Raises the API rate limit for tag resolution. Default: none.
+    github_token: ""
+
+    # [OPTIONAL] How long resolved artifact URLs are cached. Default: 30m.
+    resolve_cache_ttl: 30m
+
+    # [OPTIONAL] Maximum duration of a single image build. Default: 45m.
+    timeout: 45m
+
+    # [OPTIONAL] Maximum number of concurrent image builds. 0 means unlimited. Default: 1.
+    max_concurrent: 1
+
 # Rest API configuration.
 api:
   # [OPTIONAL] Server listening address. Default: :9000.

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -1,0 +1,38 @@
+# Local deploy (build-variant feature check)
+
+A self-contained, credential-free stack to try the debug/sanitizer build-variant feature
+end to end: the backend (with local builds enabled), the UI, and a local DynamoDB.
+
+## Run
+
+```sh
+docker compose -f deploy/local/docker-compose.yml up --build
+```
+
+Then open **http://localhost:3001**. The backend API is on **http://localhost:9000/api**.
+
+## What it does
+
+- **dynamodb-local** — in-memory DynamoDB; `ddb-init` creates the `QueryRuns` table.
+- **backend** — built from this repo. Lists Docker Hub tags anonymously, stores runs in the
+  local DynamoDB (`aws.endpoint_url`), and builds debug/sanitizer images on the host Docker
+  daemon (mounted `docker.sock`). Local builds are enabled in `config.yml`.
+- **ui** — built from `../../../clickhouse-playground-ui` with `API_URL=http://localhost:9000/api/`.
+
+## Checking the feature
+
+1. Pick a recent **version** (e.g. a `26.x.y.z` / `24.8.x.y` release tag) in the dropdown.
+2. Pick a **Build** other than `release` (e.g. `asan`).
+3. Click **Run query**. The first run resolves the version's CI artifacts and builds the
+   image locally — this takes several minutes and shows a "Building … image" status. Once
+   ready, the query runs; subsequent runs reuse the cached image.
+
+`release` builds work exactly as before (pulled from Docker Hub).
+
+## Notes
+
+- Outbound internet is required: the backend pulls `ubuntu:22.04` and the CI `.deb` packages,
+  and lists Docker Hub tags. Sanitizer/debug `.deb`s are large, so the first build is slow.
+- Build artifacts age out of CI S3 for older patch releases; if a variant fails to prepare
+  with a "report … does not exist or expired" error, pick a more recent release version.
+- This stack is for local checking only. Production uses `../docker-compose.yml`.

--- a/deploy/local/config.yml
+++ b/deploy/local/config.yml
@@ -1,0 +1,71 @@
+# Local-deploy backend config for checking the debug/sanitizer build-variant feature.
+# Listed Docker Hub tags are fetched anonymously (no auth), runs are stored in a local
+# DynamoDB, and local builds for non-release build types are enabled.
+log_level: info
+
+docker_image:
+  auth:
+    identifier: ""
+    secret: ""
+  repositories:
+    - clickhouse/clickhouse-server
+
+  os: linux
+  architecture: amd64
+
+  image_tags_cache_expiration_time: 3m
+
+  # Enable local debug/sanitizer image builds.
+  builds:
+    enabled: true
+    report_base_url: https://s3.amazonaws.com/clickhouse-test-reports
+    github_api_url: https://api.github.com
+    repository: ClickHouse/ClickHouse
+    resolve_cache_ttl: 30m
+    timeout: 45m
+    # Build several variant images in parallel so they don't queue behind each other.
+    max_concurrent: 4
+
+api:
+  address: :9000
+  server_timeout: 60s
+  cache_disabled: false
+
+limits:
+  max_query_length: 2500
+  max_output_length: 25000
+
+prometheus_address: :2112
+
+# DynamoDB credentials are dummy; the endpoint is overridden to the local DynamoDB via the
+# AWS_ENDPOINT_URL_DYNAMODB environment variable (see docker-compose.yml).
+aws:
+  access_key_id: dummy
+  secret_access_key: dummy
+  region: us-east-2
+  endpoint_url: http://dynamodb-local:8000
+  query_runs_table: QueryRuns
+
+coordinator:
+  health_check_retry_delay: 10s
+
+runners:
+  - type: DOCKER_ENGINE
+    name: default
+    max_concurrency: 10
+    weight: 100
+
+    docker_engine:
+      gc:
+        trigger_frequency: 1m
+        container_ttl: 5m
+        image_count_threshold: 50
+        image_buffer_size: 30
+
+      container:
+        cpu_limit: 2.5
+        # Sanitizer builds (asan/tsan/msan) use 2-4x the memory of release; give them headroom.
+        memory_limit_mb: 8000
+
+      prewarm:
+        max_warm_containers: 2

--- a/deploy/local/docker-compose.yml
+++ b/deploy/local/docker-compose.yml
@@ -1,0 +1,74 @@
+# Local, credential-free stack for checking the debug/sanitizer build-variant feature.
+#
+#   docker compose -f deploy/local/docker-compose.yml up --build
+#
+# Then open http://localhost:3001 (UI). The backend API is on http://localhost:9000/api.
+# Runs are stored in an in-memory DynamoDB; Docker Hub tags are listed anonymously.
+#
+# The backend builds debug/sanitizer images on the host Docker daemon (via the mounted
+# docker.sock) and needs outbound internet to pull ubuntu:22.04 and the CI .deb packages.
+
+services:
+  dynamodb-local:
+    image: amazon/dynamodb-local:latest
+    command: ["-jar", "DynamoDBLocal.jar", "-inMemory", "-sharedDb"]
+    expose:
+      - "8000"
+
+  ddb-init:
+    image: amazon/aws-cli:latest
+    depends_on:
+      - dynamodb-local
+    environment:
+      AWS_ACCESS_KEY_ID: dummy
+      AWS_SECRET_ACCESS_KEY: dummy
+      AWS_REGION: us-east-2
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - >
+        until aws dynamodb list-tables --endpoint-url http://dynamodb-local:8000 >/dev/null 2>&1; do
+          echo "waiting for dynamodb-local..."; sleep 2;
+        done;
+        aws dynamodb describe-table --table-name QueryRuns --endpoint-url http://dynamodb-local:8000 >/dev/null 2>&1 ||
+        aws dynamodb create-table --table-name QueryRuns
+        --attribute-definitions AttributeName=Id,AttributeType=S
+        --key-schema AttributeName=Id,KeyType=HASH
+        --billing-mode PAY_PER_REQUEST
+        --endpoint-url http://dynamodb-local:8000;
+        echo "dynamodb ready";
+    restart: "no"
+
+  backend:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    environment:
+      CONFIG_PATH: /config.yml
+      AWS_ENDPOINT_URL_DYNAMODB: http://dynamodb-local:8000
+      AWS_REGION: us-east-2
+      AWS_ACCESS_KEY_ID: dummy
+      AWS_SECRET_ACCESS_KEY: dummy
+    volumes:
+      - ./config.yml:/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "9000:9000"
+    depends_on:
+      ddb-init:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+  ui:
+    build:
+      context: ../../../clickhouse-playground-ui
+      dockerfile: Dockerfile
+      args:
+        # Same-origin: the UI fetches /api/* and nginx (below) proxies to the backend.
+        API_URL: /api/
+    volumes:
+      - ./nginx.ui.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "3001:80"
+    depends_on:
+      - backend
+    restart: unless-stopped

--- a/deploy/local/docker-compose.yml
+++ b/deploy/local/docker-compose.yml
@@ -60,6 +60,7 @@ services:
 
   ui:
     build:
+      # TODO: Move the Web App to this repo.
       context: ../../../clickhouse-playground-ui
       dockerfile: Dockerfile
       args:

--- a/deploy/local/nginx.ui.conf
+++ b/deploy/local/nginx.ui.conf
@@ -1,0 +1,26 @@
+# UI nginx for the local deploy: serves the static app and proxies /api/ to the backend so
+# the browser talks to the API same-origin (works regardless of which host the browser is on).
+server {
+    listen 80;
+
+    location /api/ {
+        proxy_pass http://backend:9000/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # Query runs can take up to the backend's server_timeout (60s); allow some headroom.
+        proxy_read_timeout 120s;
+        proxy_send_timeout 120s;
+    }
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+        root /usr/share/nginx/html;
+    }
+}

--- a/docs/api-specification.md
+++ b/docs/api-specification.md
@@ -109,6 +109,58 @@ curl -XGET https://fiddle.clickhouse.com/api/tags
 }
 ```
 
+### List available build types
+
+| GET    | /api/build-types |
+|--------|------------------|
+
+Get the selectable ClickHouse build types. `release` images are pulled from DockerHub; the
+other build types (`debug`, `asan`, `tsan`, `msan`, `ubsan`) are built locally on demand from
+ClickHouse CI artifacts and are only available when local builds are enabled on the server.
+
+Example:
+```yml
+curl -XGET https://fiddle.clickhouse.com/api/build-types
+
+# 200 OK
+{
+  "result": {
+    "build_types": ["release", "debug", "asan", "tsan", "msan", "ubsan"]
+  }
+}
+```
+
+### Prepare a non-release build
+
+| POST   | /api/images/prepare |
+|--------|---------------------|
+
+Non-release images are not published to DockerHub, so the server builds them locally from the
+`.deb` packages produced by ClickHouse CI on release branches. These builds are large and slow
+(minutes), so they are prepared asynchronously: call this endpoint to start the build, then poll
+`GET /api/images/status` until the state is `ready` before running a query.
+
+The request body has `version` (a tag from `/api/tags`) and `build_type`. The response payload
+has `state` (`building`, `ready`, or `failed`), an optional `detail` describing the current
+build stage while building (e.g. `Downloading packages`, `Installing packages`), and an
+optional `error` when failed. `release` always returns `ready`.
+
+Example:
+```yml
+curl -XPOST https://fiddle.clickhouse.com/api/images/prepare -d '{ \
+  "version": "24.8.1.2684", \
+  "build_type": "asan" \
+}'
+
+# 200 OK
+{ "result": { "state": "building" } }
+
+# Poll until ready:
+curl -XGET 'https://fiddle.clickhouse.com/api/images/status?version=24.8.1.2684&build_type=asan'
+# 200 OK
+{ "result": { "state": "ready" } }
+```
+
 ### Run a query
 
 | POST   | /api/runs |
@@ -135,9 +187,19 @@ for an incoming request, so it may some time to process the query
                 <td>A desired version of ClickHouse where the query will be run.</td>
             </tr>
             <tr>
-                <td rowspan=1>input</td>
+                <td rowspan=1>query</td>
                 <td rowspan=1>string</td>
                 <td>Semicolon-separated list of SQL queries that will be run.</td>
+            </tr>
+            <tr>
+                <td rowspan=1>build_type</td>
+                <td rowspan=1>string</td>
+                <td>
+                    [optional] ClickHouse build kind: <code>release</code> (default), <code>debug</code>,
+                    <code>asan</code>, <code>tsan</code>, <code>msan</code>, <code>ubsan</code>.
+                    Non-release builds must be prepared first (see <em>Prepare a non-release build</em>);
+                    otherwise the request fails with <code>409</code>.
+                </td>
             </tr>
         </tbody>
     </table>
@@ -236,6 +298,11 @@ You can get information about a previously processed query.
                 <td rowspan=1>version</td>
                 <td rowspan=1>string</td>
                 <td>What ClickHouse version has been used to run the query.</td>
+            </tr>
+            <tr>
+                <td rowspan=1>build_type</td>
+                <td rowspan=1>string</td>
+                <td>Which build type was used (omitted for release builds).</td>
             </tr>
             <tr>
                 <td>input</td>

--- a/docs/api-specification.md
+++ b/docs/api-specification.md
@@ -140,10 +140,40 @@ Non-release images are not published to DockerHub, so the server builds them loc
 (minutes), so they are prepared asynchronously: call this endpoint to start the build, then poll
 `GET /api/images/status` until the state is `ready` before running a query.
 
-The request body has `version` (a tag from `/api/tags`) and `build_type`. The response payload
-has `state` (`building`, `ready`, or `failed`), an optional `detail` describing the current
-build stage while building (e.g. `Downloading packages`, `Installing packages`), and an
-optional `error` when failed. `release` always returns `ready`.
+<details>
+      <summary>Response payload</summary>
+      <table>
+          <thead>
+              <tr>
+                  <th>Field name</th>
+                  <th>Field type</th>
+                  <th>Description</th>
+              </tr>
+          </thead>
+          <tbody>
+              <tr>
+                  <td>state</td>
+                  <td>string</td>
+                  <td><code>building</code>, <code>ready</code>, or <code>failed</code>. Release builds always return <code>ready</code>.</td>
+              </tr>
+              <tr>
+                  <td>detail</td>
+                  <td>string</td>
+                  <td>[optional] Current build stage, such as <code>Downloading packages</code>.</td>
+              </tr>
+              <tr>
+                  <td>logs</td>
+                  <td>string</td>
+                  <td>[optional] Build logs, when available.</td>
+              </tr>
+              <tr>
+                  <td>error</td>
+                  <td>string</td>
+                  <td>[optional] Error description when the build has failed.</td>
+              </tr>
+          </tbody>
+      </table>
+  </details>
 
 Example:
 ```yml

--- a/internal/buildtype/buildtype.go
+++ b/internal/buildtype/buildtype.go
@@ -1,0 +1,67 @@
+// Package buildtype enumerates the kinds of ClickHouse builds the playground can run.
+//
+// The default build type is Release: images are pulled from the public Docker Hub
+// repositories. The other build types (debug and sanitizers) are not published to
+// Docker Hub; their images are built locally from the .deb packages produced by
+// ClickHouse CI on release branches (see the internal/cibuild package).
+package buildtype
+
+import (
+	"fmt"
+	"strings"
+)
+
+// BuildType identifies the kind of ClickHouse build to run.
+type BuildType string
+
+const (
+	Release BuildType = "release"
+	Debug   BuildType = "debug"
+	ASAN    BuildType = "asan"
+	TSAN    BuildType = "tsan"
+	MSAN    BuildType = "msan"
+	UBSAN   BuildType = "ubsan"
+)
+
+// Default is the build type assumed when a request does not specify one.
+const Default = Release
+
+// all lists every supported build type in display order.
+var all = []BuildType{Release, Debug, ASAN, TSAN, MSAN, UBSAN}
+
+// All returns every supported build type.
+func All() []BuildType {
+	out := make([]BuildType, len(all))
+	copy(out, all)
+
+	return out
+}
+
+// Parse validates and normalizes a raw build type string.
+// An empty string is treated as the default (Release) for backward compatibility.
+func Parse(raw string) (BuildType, error) {
+	if raw == "" {
+		return Default, nil
+	}
+
+	bt := BuildType(strings.ToLower(strings.TrimSpace(raw)))
+	for _, known := range all {
+		if bt == known {
+			return bt, nil
+		}
+	}
+
+	return "", fmt.Errorf("unknown build type %q", raw)
+}
+
+// IsRelease reports whether the build type is the default Docker Hub release build.
+func (b BuildType) IsRelease() bool {
+	return b == Release || b == ""
+}
+
+// String returns the build type as a string. It also doubles as the variant token used to
+// match a CI build job (e.g. "asan" matches a "Build (amd_asan)" or "Build (amd_asan_ubsan)"
+// job).
+func (b BuildType) String() string {
+	return string(b)
+}

--- a/internal/buildtype/buildtype_test.go
+++ b/internal/buildtype/buildtype_test.go
@@ -1,0 +1,58 @@
+package buildtype
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	cases := []struct {
+		raw     string
+		want    BuildType
+		wantErr bool
+	}{
+		{"", Release, false},
+		{"release", Release, false},
+		{"debug", Debug, false},
+		{"ASAN", ASAN, false},
+		{" tsan ", TSAN, false},
+		{"msan", MSAN, false},
+		{"ubsan", UBSAN, false},
+		{"coverage", "", true},
+		{"amd_asan", "", true},
+	}
+
+	for _, c := range cases {
+		got, err := Parse(c.raw)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("Parse(%q): expected error, got %q", c.raw, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("Parse(%q): unexpected error: %v", c.raw, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("Parse(%q) = %q, want %q", c.raw, got, c.want)
+		}
+	}
+}
+
+func TestIsRelease(t *testing.T) {
+	if !Release.IsRelease() {
+		t.Error("Release.IsRelease() = false, want true")
+	}
+	if !BuildType("").IsRelease() {
+		t.Error(`BuildType("").IsRelease() = false, want true`)
+	}
+	if ASAN.IsRelease() {
+		t.Error("ASAN.IsRelease() = true, want false")
+	}
+}
+
+func TestAllIsCopy(t *testing.T) {
+	a := All()
+	a[0] = "mutated"
+	if All()[0] != Release {
+		t.Error("All() returned a slice backed by shared state")
+	}
+}

--- a/internal/cibuild/config.go
+++ b/internal/cibuild/config.go
@@ -1,0 +1,12 @@
+package cibuild
+
+import "time"
+
+// DefaultCacheTTL is how long a successfully resolved BuildSpec is cached.
+// Resolved artifacts are immutable, so this mostly avoids repeated GitHub/S3 calls.
+const DefaultCacheTTL = 30 * time.Minute
+
+type Config struct {
+	// CacheTTL bounds how long resolved specs are cached. Defaults to DefaultCacheTTL.
+	CacheTTL time.Duration
+}

--- a/internal/cibuild/resolver.go
+++ b/internal/cibuild/resolver.go
@@ -1,0 +1,241 @@
+// Package cibuild resolves a released ClickHouse version and build type into the set of
+// .deb package URLs needed to build a matching Docker image locally.
+//
+// Release builds are served from Docker Hub and are not handled here. For debug and
+// sanitizer builds, the resolver maps the version to its commit sha and reads the
+// per-commit ReleaseBranchCI report to find the produced package URLs.
+package cibuild
+
+import (
+	"context"
+	"path"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/lodthe/clickhouse-playground/internal/buildtype"
+	"github.com/lodthe/clickhouse-playground/pkg/clickhousebuilds"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+// fullVersionRe matches a fully qualified release version like "26.3.14.45".
+var fullVersionRe = regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+$`)
+
+// maxCandidateCommits bounds how many recent release-branch commits are probed when a version
+// does not map to an exact tagged commit (e.g. a "major.minor" ref like "26.2").
+const maxCandidateCommits = 5
+
+// BuildSpec describes how to build a ClickHouse image for a non-release build type.
+type BuildSpec struct {
+	// Version is the ClickHouse version, passed as the VERSION Docker build arg.
+	Version string
+	// DownloadURLs are the .deb package URLs passed as DIRECT_DOWNLOAD_URLS.
+	DownloadURLs []string
+}
+
+// Resolver maps a (version, build type) pair to a BuildSpec.
+type Resolver interface {
+	Resolve(ctx context.Context, version string, bt buildtype.BuildType) (BuildSpec, error)
+}
+
+// buildsClient is the subset of clickhousebuilds.Client the resolver depends on.
+type buildsClient interface {
+	ResolveCommitSHA(ctx context.Context, ref string) (string, error)
+	GetRecentCommitSHAs(ctx context.Context, ref string, limit int) ([]string, error)
+	GetReleaseBranchReport(ctx context.Context, ref, sha string) (*clickhousebuilds.Report, error)
+}
+
+// requiredPackagePrefixes lists the .deb packages the official Dockerfile.ubuntu installs
+// (PACKAGES="clickhouse-client clickhouse-server clickhouse-common-static"). The trailing
+// underscore is significant: it separates the package name from the version and prevents
+// matching "clickhouse-common-static-dbg" or "clickhouse-keeper".
+var requiredPackagePrefixes = []string{
+	"clickhouse-common-static_",
+	"clickhouse-server_",
+	"clickhouse-client_",
+}
+
+type cacheEntry struct {
+	spec      BuildSpec
+	expiresAt time.Time
+}
+
+type resolver struct {
+	cli    buildsClient
+	logger zerolog.Logger
+	ttl    time.Duration
+
+	mu    sync.Mutex
+	cache map[string]cacheEntry
+}
+
+// NewResolver creates a Resolver backed by the given client.
+func NewResolver(logger zerolog.Logger, cli buildsClient, cfg Config) Resolver {
+	ttl := cfg.CacheTTL
+	if ttl <= 0 {
+		ttl = DefaultCacheTTL
+	}
+
+	return &resolver{
+		cli:    cli,
+		logger: logger,
+		ttl:    ttl,
+		cache:  make(map[string]cacheEntry),
+	}
+}
+
+func (r *resolver) Resolve(ctx context.Context, version string, bt buildtype.BuildType) (BuildSpec, error) {
+	if bt.IsRelease() {
+		return BuildSpec{}, errors.New("release builds are served from Docker Hub, not built locally")
+	}
+
+	key := version + "/" + bt.String()
+	if spec, ok := r.cached(key); ok {
+		return spec, nil
+	}
+
+	ref, err := releaseBranchRef(version)
+	if err != nil {
+		return BuildSpec{}, err
+	}
+
+	shas, err := r.candidateSHAs(ctx, version, ref)
+	if err != nil {
+		return BuildSpec{}, err
+	}
+
+	// Probe candidate commits newest-first until one has a successful build for the variant.
+	var lastErr error
+	for _, sha := range shas {
+		report, err := r.cli.GetReleaseBranchReport(ctx, ref, sha)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		job, found := report.AMDBuildJob(bt.String())
+		if !found {
+			lastErr = errors.Errorf("no successful amd64 %s build at %s@%s", bt, ref, sha)
+			continue
+		}
+
+		urls, err := selectPackageURLs(job.Links)
+		if err != nil {
+			lastErr = errors.Wrapf(err, "%s build artifacts at %s", bt, sha)
+			continue
+		}
+
+		spec := BuildSpec{Version: version, DownloadURLs: urls}
+		r.store(key, spec)
+
+		r.logger.Info().
+			Str("version", version).
+			Str("build_type", bt.String()).
+			Str("ref", ref).
+			Str("sha", sha).
+			Int("packages", len(urls)).
+			Msg("resolved CI build artifacts")
+
+		return spec, nil
+	}
+
+	if lastErr == nil {
+		lastErr = errors.Errorf("no commits found for %s", ref)
+	}
+
+	return BuildSpec{}, errors.Wrapf(lastErr, "no %s build available for %s", bt, version)
+}
+
+// candidateSHAs returns the commit shas to probe for a version, newest-first. A fully
+// qualified version is mapped to its "-stable" tag commit; short refs (and tag-resolution
+// failures) fall back to the most recent commits on the release branch.
+func (r *resolver) candidateSHAs(ctx context.Context, version, ref string) ([]string, error) {
+	var shas []string
+
+	if fullVersionRe.MatchString(version) {
+		tag := "v" + version + "-stable"
+		sha, err := r.cli.ResolveCommitSHA(ctx, tag)
+		if err == nil {
+			shas = append(shas, sha)
+		} else {
+			r.logger.Debug().Err(err).Str("tag", tag).Msg("tag resolution failed; falling back to recent branch commits")
+		}
+	}
+
+	recent, err := r.cli.GetRecentCommitSHAs(ctx, ref, maxCandidateCommits)
+	if err != nil {
+		if len(shas) > 0 {
+			// We still have the tagged commit to try.
+			return shas, nil
+		}
+		return nil, errors.Wrapf(err, "failed to list commits for %s", ref)
+	}
+
+	// Append recent commits, skipping the tagged sha if already present.
+	for _, sha := range recent {
+		if len(shas) == 0 || shas[0] != sha {
+			shas = append(shas, sha)
+		}
+	}
+
+	if len(shas) == 0 {
+		return nil, errors.Errorf("no commits found for release branch %s", ref)
+	}
+
+	return shas, nil
+}
+
+func (r *resolver) cached(key string) (BuildSpec, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, ok := r.cache[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		return BuildSpec{}, false
+	}
+
+	return entry.spec, true
+}
+
+func (r *resolver) store(key string, spec BuildSpec) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.cache[key] = cacheEntry{spec: spec, expiresAt: time.Now().Add(r.ttl)}
+}
+
+// releaseBranchRef extracts the "<major>.<minor>" release-branch ref from a version.
+func releaseBranchRef(version string) (string, error) {
+	parts := strings.Split(version, ".")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", errors.Errorf("version %q is not a fully qualified release version", version)
+	}
+
+	return parts[0] + "." + parts[1], nil
+}
+
+// selectPackageURLs picks exactly one URL for each required package from the build job's links.
+func selectPackageURLs(links []string) ([]string, error) {
+	urls := make([]string, 0, len(requiredPackagePrefixes))
+
+	for _, prefix := range requiredPackagePrefixes {
+		var matched string
+		for _, link := range links {
+			base := path.Base(link)
+			if strings.HasPrefix(base, prefix) && strings.HasSuffix(base, ".deb") {
+				matched = link
+				break
+			}
+		}
+		if matched == "" {
+			return nil, errors.Errorf("missing package %s*.deb", prefix)
+		}
+
+		urls = append(urls, matched)
+	}
+
+	return urls, nil
+}

--- a/internal/cibuild/resolver_test.go
+++ b/internal/cibuild/resolver_test.go
@@ -1,0 +1,220 @@
+package cibuild
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lodthe/clickhouse-playground/internal/buildtype"
+	"github.com/lodthe/clickhouse-playground/pkg/clickhousebuilds"
+
+	"github.com/rs/zerolog"
+)
+
+type mockClient struct {
+	sha    string
+	shaErr error
+
+	recentSHAs []string
+	recentErr  error
+
+	report    *clickhousebuilds.Report
+	reportErr error
+
+	gotRef string
+}
+
+func (m *mockClient) ResolveCommitSHA(_ context.Context, _ string) (string, error) {
+	return m.sha, m.shaErr
+}
+
+func (m *mockClient) GetRecentCommitSHAs(_ context.Context, _ string, _ int) ([]string, error) {
+	return m.recentSHAs, m.recentErr
+}
+
+func (m *mockClient) GetReleaseBranchReport(_ context.Context, ref, _ string) (*clickhousebuilds.Report, error) {
+	m.gotRef = ref
+	return m.report, m.reportErr
+}
+
+const base = "https://clickhouse-builds.s3.amazonaws.com/REFs/26.3/abc/build_amd_asan/"
+
+func asanReport() *clickhousebuilds.Report {
+	return &clickhousebuilds.Report{
+		Name:   "ReleaseBranchCI",
+		Status: "success",
+		Results: []clickhousebuilds.Result{
+			{Name: "Build (amd_release)", Status: "success"},
+			{
+				Name:   "Build (amd_asan)",
+				Status: "success",
+				Links: []string{
+					base + "clickhouse",
+					base + "clickhouse-common-static-dbg_26.3.14.45_amd64.deb",
+					base + "clickhouse-common-static_26.3.14.45_amd64.deb",
+					base + "clickhouse-keeper_26.3.14.45_amd64.deb",
+					base + "clickhouse-client_26.3.14.45_amd64.deb",
+					base + "clickhouse-server_26.3.14.45_amd64.deb",
+					base + "job.log",
+				},
+			},
+		},
+	}
+}
+
+func newTestResolver(c buildsClient) *resolver {
+	return &resolver{cli: c, logger: zerolog.Nop(), ttl: DefaultCacheTTL, cache: map[string]cacheEntry{}}
+}
+
+func TestResolveSuccess(t *testing.T) {
+	m := &mockClient{sha: "abc", report: asanReport()}
+	r := newTestResolver(m)
+
+	spec, err := r.Resolve(context.Background(), "26.3.14.45", buildtype.ASAN)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.gotRef != "26.3" {
+		t.Errorf("ref = %q, want 26.3", m.gotRef)
+	}
+	if spec.Version != "26.3.14.45" {
+		t.Errorf("version = %q", spec.Version)
+	}
+
+	want := []string{
+		base + "clickhouse-common-static_26.3.14.45_amd64.deb",
+		base + "clickhouse-server_26.3.14.45_amd64.deb",
+		base + "clickhouse-client_26.3.14.45_amd64.deb",
+	}
+	if len(spec.DownloadURLs) != len(want) {
+		t.Fatalf("got %d urls, want %d: %v", len(spec.DownloadURLs), len(want), spec.DownloadURLs)
+	}
+	for i := range want {
+		if spec.DownloadURLs[i] != want[i] {
+			t.Errorf("url[%d] = %q, want %q", i, spec.DownloadURLs[i], want[i])
+		}
+	}
+}
+
+func TestResolveShortRefUsesBranchCommits(t *testing.T) {
+	// A "major.minor" ref does not map to a -stable tag; it must fall back to recent commits.
+	m := &mockClient{recentSHAs: []string{"latestsha"}, report: asanReport()}
+	r := newTestResolver(m)
+
+	spec, err := r.Resolve(context.Background(), "26.2", buildtype.ASAN)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.gotRef != "26.2" {
+		t.Errorf("ref = %q, want 26.2", m.gotRef)
+	}
+	if len(spec.DownloadURLs) != 3 {
+		t.Errorf("got %d urls, want 3", len(spec.DownloadURLs))
+	}
+}
+
+func TestResolveFullVersionFallsBackToBranch(t *testing.T) {
+	// Full version whose -stable tag does not exist must fall back to recent branch commits.
+	m := &mockClient{
+		shaErr:     context.Canceled, // tag resolution fails
+		recentSHAs: []string{"branchsha"},
+		report:     asanReport(),
+	}
+	r := newTestResolver(m)
+
+	if _, err := r.Resolve(context.Background(), "26.3.99.99", buildtype.ASAN); err != nil {
+		t.Fatalf("expected fallback to succeed, got: %v", err)
+	}
+}
+
+func TestResolveCachesResult(t *testing.T) {
+	m := &mockClient{sha: "abc", report: asanReport()}
+	r := newTestResolver(m)
+
+	if _, err := r.Resolve(context.Background(), "26.3.14.45", buildtype.ASAN); err != nil {
+		t.Fatalf("first resolve failed: %v", err)
+	}
+	// Break the client; a cached result must still be returned.
+	m.report = nil
+	m.reportErr = context.Canceled
+	if _, err := r.Resolve(context.Background(), "26.3.14.45", buildtype.ASAN); err != nil {
+		t.Fatalf("cached resolve failed: %v", err)
+	}
+}
+
+func TestResolveReleaseRejected(t *testing.T) {
+	r := newTestResolver(&mockClient{})
+	if _, err := r.Resolve(context.Background(), "26.3.14.45", buildtype.Release); err == nil {
+		t.Error("expected error for release build type")
+	}
+}
+
+func TestResolveErrors(t *testing.T) {
+	cases := []struct {
+		name    string
+		client  *mockClient
+		version string
+		bt      buildtype.BuildType
+	}{
+		{
+			name:    "bad version",
+			client:  &mockClient{sha: "abc", report: asanReport()},
+			version: "head",
+			bt:      buildtype.ASAN,
+		},
+		{
+			name:    "missing job",
+			client:  &mockClient{sha: "abc", report: asanReport()},
+			version: "26.3.14.45",
+			bt:      buildtype.TSAN, // no tsan job in fixture
+		},
+		{
+			name: "failed job",
+			client: &mockClient{sha: "abc", report: &clickhousebuilds.Report{
+				Results: []clickhousebuilds.Result{{Name: "Build (amd_asan)", Status: "failure"}},
+			}},
+			version: "26.3.14.45",
+			bt:      buildtype.ASAN,
+		},
+		{
+			name: "missing package",
+			client: &mockClient{sha: "abc", report: &clickhousebuilds.Report{
+				Results: []clickhousebuilds.Result{{
+					Name:   "Build (amd_asan)",
+					Status: "success",
+					Links:  []string{base + "clickhouse-server_26.3.14.45_amd64.deb"},
+				}},
+			}},
+			version: "26.3.14.45",
+			bt:      buildtype.ASAN,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := newTestResolver(c.client)
+			if _, err := r.Resolve(context.Background(), c.version, c.bt); err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestReleaseBranchRef(t *testing.T) {
+	cases := map[string]string{
+		"26.3.14.45":  "26.3",
+		"24.8.1.2684": "24.8",
+	}
+	for version, want := range cases {
+		got, err := releaseBranchRef(version)
+		if err != nil {
+			t.Errorf("releaseBranchRef(%q): %v", version, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("releaseBranchRef(%q) = %q, want %q", version, got, want)
+		}
+	}
+	if _, err := releaseBranchRef("26"); err == nil {
+		t.Error("expected error for single-part version")
+	}
+}

--- a/internal/dockertag/cache.go
+++ b/internal/dockertag/cache.go
@@ -78,7 +78,7 @@ func (c *Cache) backgroundUpdate() {
 }
 
 func (c *Cache) normalizeTag(tag string) string {
-	return strings.ToLower(tag)
+	return strings.ToLower(strings.TrimSpace(tag))
 }
 
 // GetAll returns all known tags for the given image.
@@ -139,11 +139,22 @@ func (c *Cache) asyncUpdate() {
 		atomic.StoreInt32(&c.updating, 0)
 	}()
 
+	_ = c.fetchAndStore()
+}
+
+// Update synchronously fetches the image list and refreshes the cache. It is intended for a
+// blocking initial load at startup so the server does not reject valid versions while the
+// first background fetch is still in flight.
+func (c *Cache) Update() error {
+	return c.fetchAndStore()
+}
+
+func (c *Cache) fetchAndStore() error {
 	startedAt := time.Now()
 
 	images, imgByTag, err := c.getImagesFromSeveralRepositories(c.config.Repositories)
 	if err != nil {
-		return
+		return err
 	}
 
 	func() {
@@ -156,6 +167,8 @@ func (c *Cache) asyncUpdate() {
 	}()
 
 	c.logger.Debug().Dur("elapsed", time.Since(startedAt)).Int("tag_count", len(imgByTag)).Msg("docker image cache has been updated")
+
+	return nil
 }
 
 // getImagesFromSeveralRepositories fetches images from the given list of repositories.

--- a/internal/qrunner/coordinator/coordinator.go
+++ b/internal/qrunner/coordinator/coordinator.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/lodthe/clickhouse-playground/internal/buildtype"
 	"github.com/lodthe/clickhouse-playground/internal/qrunner"
 	"github.com/lodthe/clickhouse-playground/internal/queryrun"
 
@@ -181,4 +182,62 @@ func (c *Coordinator) RunQuery(ctx context.Context, run *queryrun.Run) (output s
 	}
 
 	return output, err
+}
+
+// EnsureImage fans out to every alive runner and aggregates their statuses. Because a query
+// may be dispatched to any alive runner, the image is only considered ready once all alive
+// runners report it ready. If any runner is still building, the result is building; otherwise
+// the first failure (or error) is returned.
+func (c *Coordinator) EnsureImage(ctx context.Context, version string, bt buildtype.BuildType) (qrunner.ImageStatus, error) {
+	if bt.IsRelease() {
+		return qrunner.ImageStatus{State: qrunner.ImageReady}, nil
+	}
+
+	var (
+		alive    int
+		building *qrunner.ImageStatus
+		failed   *qrunner.ImageStatus
+		firstErr error
+	)
+
+	for _, r := range c.runners {
+		if r.weight == 0 || !r.IsAlive() {
+			continue
+		}
+		alive++
+
+		status, err := r.underlying.EnsureImage(ctx, version, bt)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+
+		switch status.State {
+		case qrunner.ImageBuilding:
+			s := status
+			building = &s
+		case qrunner.ImageFailed:
+			s := status
+			failed = &s
+		case qrunner.ImageReady:
+		}
+	}
+
+	switch {
+	case alive == 0:
+		if firstErr != nil {
+			return qrunner.ImageStatus{}, firstErr
+		}
+		return qrunner.ImageStatus{}, qrunner.ErrNoAvailableRunners
+	case building != nil:
+		return *building, nil
+	case failed != nil:
+		return *failed, nil
+	case firstErr != nil:
+		return qrunner.ImageStatus{}, firstErr
+	default:
+		return qrunner.ImageStatus{State: qrunner.ImageReady}, nil
+	}
 }

--- a/internal/qrunner/coordinator/coordinator.go
+++ b/internal/qrunner/coordinator/coordinator.go
@@ -200,6 +200,8 @@ func (c *Coordinator) EnsureImage(ctx context.Context, version string, bt buildt
 		firstErr error
 	)
 
+	// TODO: Consider the image ready once any runner has built it; route each
+	// request to a runner where the image is available.
 	for _, r := range c.runners {
 		if r.weight == 0 || !r.IsAlive() {
 			continue

--- a/internal/qrunner/dockerengine/build_manager.go
+++ b/internal/qrunner/dockerengine/build_manager.go
@@ -1,0 +1,409 @@
+package dockerengine
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io/fs"
+	"path"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/lodthe/clickhouse-playground/internal/buildtype"
+	"github.com/lodthe/clickhouse-playground/internal/cibuild"
+	"github.com/lodthe/clickhouse-playground/internal/qrunner"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+// retryCooldown is how long a failed build is reported as failed before EnsureImage
+// will start a fresh attempt. It prevents poll loops from rebuilding a failing image
+// repeatedly while still allowing eventual retries.
+const retryCooldown = time.Minute
+
+// File modes for the entries written into the build-context tar.
+const (
+	tarFileMode       = 0o644
+	tarExecutableMode = 0o755
+)
+
+type buildRecord struct {
+	state      qrunner.ImageState
+	stage      string
+	logLines   []string
+	err        error
+	finishedAt time.Time
+}
+
+// Bounds on the build log tail kept in memory and streamed to the client.
+const (
+	maxLogLines   = 200
+	maxLogLineLen = 500
+	logLineSep    = "\n"
+)
+
+// Build stages reported to the user while an image is being built.
+const (
+	stageStarting   = "Starting build"
+	stageQueued     = "Waiting in build queue"
+	stagePreparing  = "Preparing build"
+	stagePullBase   = "Pulling base image"
+	stageDownload   = "Downloading packages"
+	stageInstall    = "Installing packages"
+	stageFinalizing = "Finalizing image"
+)
+
+// buildManager builds and caches debug/sanitizer images locally, ensuring at most one
+// in-flight build per image and bounding overall build concurrency.
+type buildManager struct {
+	mainCtx  context.Context
+	logger   zerolog.Logger
+	engine   *engineProvider
+	resolver cibuild.Resolver
+	cfg      BuildSettings
+
+	sem chan struct{} // bounds concurrent builds; nil means unlimited
+
+	mu      sync.Mutex
+	records map[string]*buildRecord // keyed by image FQN
+}
+
+func newBuildManager(ctx context.Context, logger zerolog.Logger, engine *engineProvider, resolver cibuild.Resolver, cfg BuildSettings) *buildManager {
+	var sem chan struct{}
+	if cfg.MaxConcurrent > 0 {
+		sem = make(chan struct{}, cfg.MaxConcurrent)
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = DefaultBuildTimeout
+	}
+
+	return &buildManager{
+		mainCtx:  ctx,
+		logger:   logger.With().Str("component", "image_builder").Logger(),
+		engine:   engine,
+		resolver: resolver,
+		cfg:      cfg,
+		sem:      sem,
+		records:  make(map[string]*buildRecord),
+	}
+}
+
+func (m *buildManager) enabled() bool {
+	return m != nil && m.cfg.Enabled && m.resolver != nil
+}
+
+// resolve maps a (version, build type) to its image FQN and build spec.
+func (m *buildManager) resolve(ctx context.Context, version string, bt buildtype.BuildType) (fqn string, spec cibuild.BuildSpec, err error) {
+	spec, err = m.resolver.Resolve(ctx, version, bt)
+	if err != nil {
+		return "", cibuild.BuildSpec{}, err
+	}
+
+	return PlaygroundBuildImageName(bt, version, spec.DownloadURLs), spec, nil
+}
+
+func (m *buildManager) imageExists(ctx context.Context, fqn string) bool {
+	_, err := m.engine.getImageByID(ctx, fqn)
+
+	return err == nil
+}
+
+// Ensure makes sure the image for the given version and build type is present, starting a
+// background build if necessary. It is non-blocking and returns the current status.
+func (m *buildManager) Ensure(ctx context.Context, version string, bt buildtype.BuildType) (qrunner.ImageStatus, error) {
+	if !m.enabled() {
+		return qrunner.ImageStatus{}, qrunner.ErrBuildsNotSupported
+	}
+
+	fqn, spec, err := m.resolve(ctx, version, bt)
+	if err != nil {
+		return qrunner.ImageStatus{}, err
+	}
+
+	if m.imageExists(ctx, fqn) {
+		return qrunner.ImageStatus{State: qrunner.ImageReady}, nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rec := m.records[fqn]
+	switch {
+	case rec != nil && rec.state == qrunner.ImageBuilding:
+		return qrunner.ImageStatus{
+			State:  qrunner.ImageBuilding,
+			Detail: rec.stage,
+			Logs:   strings.Join(rec.logLines, logLineSep),
+		}, nil
+
+	case rec != nil && rec.state == qrunner.ImageFailed && time.Since(rec.finishedAt) < retryCooldown:
+		return qrunner.ImageStatus{
+			State: qrunner.ImageFailed,
+			Error: errString(rec.err),
+			Logs:  strings.Join(rec.logLines, logLineSep),
+		}, nil
+	}
+
+	m.records[fqn] = &buildRecord{state: qrunner.ImageBuilding, stage: stageStarting}
+	go m.build(fqn, version, bt, spec)
+
+	return qrunner.ImageStatus{State: qrunner.ImageBuilding, Detail: stageStarting}, nil
+}
+
+// ansiEscapeRe matches ANSI/CSI escape sequences (e.g. wget's colored progress output).
+var ansiEscapeRe = regexp.MustCompile("\x1b\\[[0-9;]*[a-zA-Z]")
+
+// setStage sets the reported progress stage of an in-flight build directly (used for
+// transitions that have no corresponding build-output line, e.g. queueing).
+func (m *buildManager) setStage(fqn, stage string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if rec := m.records[fqn]; rec != nil && rec.state == qrunner.ImageBuilding {
+		rec.stage = stage
+	}
+}
+
+// onBuildLine records a build output chunk: it advances the progress stage (if a line
+// carries a stage signal) and appends the cleaned lines to the streamed log tail. A single
+// Docker stream chunk may contain several lines and carriage returns (wget progress), so it
+// is split into individual non-empty lines; consecutive progress-bar lines are collapsed to
+// a single updating line to avoid flooding the log.
+func (m *buildManager) onBuildLine(fqn, chunk string) {
+	lines, stage := parseBuildChunk(chunk)
+	if len(lines) == 0 && stage == "" {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rec := m.records[fqn]
+	if rec == nil || rec.state != qrunner.ImageBuilding {
+		return
+	}
+
+	if stage != "" {
+		rec.stage = stage
+	}
+	rec.appendLogs(lines)
+}
+
+// parseBuildChunk splits a Docker stream chunk into cleaned, non-empty log lines and the last
+// progress stage signaled by any of them.
+func parseBuildChunk(chunk string) (lines []string, stage string) {
+	chunk = ansiEscapeRe.ReplaceAllString(chunk, "")
+	chunk = strings.ReplaceAll(chunk, "\r", logLineSep)
+
+	for _, line := range strings.Split(chunk, logLineSep) {
+		line = strings.TrimRight(line, " \t")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if len(line) > maxLogLineLen {
+			line = line[:maxLogLineLen]
+		}
+		if s := classifyBuildStage(line); s != "" {
+			stage = s
+		}
+		lines = append(lines, line)
+	}
+
+	return lines, stage
+}
+
+// appendLogs adds lines to the record's log tail, collapsing consecutive progress-bar updates
+// into one live-updating line, and trims the tail to the cap.
+func (r *buildRecord) appendLogs(lines []string) {
+	for _, line := range lines {
+		n := len(r.logLines)
+		if isProgressLine(line) && n > 0 && isProgressLine(r.logLines[n-1]) {
+			r.logLines[n-1] = line
+			continue
+		}
+		r.logLines = append(r.logLines, line)
+	}
+	if len(r.logLines) > maxLogLines {
+		r.logLines = r.logLines[len(r.logLines)-maxLogLines:]
+	}
+}
+
+// isProgressLine reports whether a log line is a wget progress-bar update.
+func isProgressLine(line string) bool {
+	return strings.Contains(line, "%[") || strings.Contains(line, "MB/s") || strings.Contains(line, "KB/s")
+}
+
+// classifyBuildStage maps a Docker build output line to a user-facing stage, or "" if the
+// line carries no stage signal (the current stage is then kept).
+func classifyBuildStage(line string) string {
+	switch {
+	case strings.Contains(line, "installing from custom predefined urls"),
+		strings.Contains(line, ".deb"):
+		return stageDownload
+	case strings.Contains(line, "Selecting previously unselected"),
+		strings.Contains(line, "Preparing to unpack"),
+		strings.Contains(line, "Unpacking "),
+		strings.Contains(line, "Setting up "):
+		return stageInstall
+	case strings.Contains(line, "system.build_options"),
+		strings.Contains(line, "locale-gen"),
+		strings.Contains(line, "exporting to"),
+		strings.Contains(line, "naming to"),
+		strings.Contains(line, "Successfully tagged"):
+		return stageFinalizing
+	case strings.Contains(line, "Pulling from"),
+		strings.Contains(line, "Pulling fs layer"),
+		strings.Contains(line, "Pull complete"),
+		strings.Contains(line, "Already exists"),
+		strings.Contains(line, "Extracting"):
+		return stagePullBase
+	default:
+		return ""
+	}
+}
+
+func (m *buildManager) build(fqn, version string, bt buildtype.BuildType, spec cibuild.BuildSpec) {
+	if m.sem != nil {
+		// Tell the user the build is queued (another build holds the slot) instead of
+		// leaving it on "Starting build" with no output.
+		m.setStage(fqn, stageQueued)
+		select {
+		case m.sem <- struct{}{}:
+			defer func() { <-m.sem }()
+		case <-m.mainCtx.Done():
+			m.finish(fqn, m.mainCtx.Err())
+			return
+		}
+	}
+
+	m.setStage(fqn, stagePreparing)
+
+	ctx, cancel := context.WithTimeout(m.mainCtx, m.cfg.Timeout)
+	defer cancel()
+
+	startedAt := time.Now()
+	m.logger.Info().Str("image", fqn).Str("version", version).Str("build_type", bt.String()).Msg("starting image build")
+
+	buildCtx, err := buildTarContext()
+	if err != nil {
+		m.finish(fqn, errors.Wrap(err, "failed to assemble build context"))
+		return
+	}
+
+	args := buildArgs(spec)
+	err = m.engine.buildImage(ctx, buildCtx, fqn, args, func(line string) {
+		m.onBuildLine(fqn, line)
+	})
+	if err != nil {
+		m.logger.Error().Err(err).Str("image", fqn).Msg("image build failed")
+		m.finish(fqn, err)
+
+		return
+	}
+
+	m.logger.Info().Str("image", fqn).Dur("elapsed", time.Since(startedAt)).Msg("image build finished")
+	m.finish(fqn, nil)
+}
+
+func (m *buildManager) finish(fqn string, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rec := m.records[fqn]
+	if rec == nil {
+		rec = &buildRecord{}
+		m.records[fqn] = rec
+	}
+
+	rec.finishedAt = time.Now()
+	rec.err = err
+	if err != nil {
+		// Keep the log tail so the client can surface why the build failed.
+		rec.state = qrunner.ImageFailed
+	} else {
+		rec.state = qrunner.ImageReady
+		rec.logLines = nil
+	}
+}
+
+// buildArgs assembles the Docker build args for a non-release build.
+func buildArgs(spec cibuild.BuildSpec) map[string]*string {
+	urls := strings.Join(spec.DownloadURLs, " ")
+	version := spec.Version
+	// The clickhouse-builds S3 bucket intermittently returns 5xx during downloads, so use a
+	// more generous retry budget than the Dockerfile's defaults (5 retries x 1s).
+	wgetRetries := "10"
+	wgetRetryDelay := "5"
+
+	return map[string]*string{
+		"DIRECT_DOWNLOAD_URLS": &urls,
+		"VERSION":              &version,
+		"WGET_RETRIES":         &wgetRetries,
+		"WGET_RETRY_DELAY":     &wgetRetryDelay,
+	}
+}
+
+// buildTarContext builds an in-memory tar archive of the embedded build context.
+func buildTarContext() (*bytes.Buffer, error) {
+	buf := new(bytes.Buffer)
+	tw := tar.NewWriter(buf)
+
+	entries, err := buildContextFS.ReadDir(buildContextDir)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read embedded build context")
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		err = writeTarFile(tw, entry)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, errors.Wrap(err, "failed to close tar writer")
+	}
+
+	return buf, nil
+}
+
+func writeTarFile(tw *tar.Writer, entry fs.DirEntry) error {
+	data, err := buildContextFS.ReadFile(path.Join(buildContextDir, entry.Name()))
+	if err != nil {
+		return errors.Wrapf(err, "failed to read %s", entry.Name())
+	}
+
+	var mode int64 = tarFileMode
+	if strings.HasSuffix(entry.Name(), ".sh") {
+		mode = tarExecutableMode
+	}
+
+	hdr := &tar.Header{
+		Name: entry.Name(),
+		Mode: mode,
+		Size: int64(len(data)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return errors.Wrapf(err, "failed to write tar header for %s", entry.Name())
+	}
+	if _, err := tw.Write(data); err != nil {
+		return errors.Wrapf(err, "failed to write tar body for %s", entry.Name())
+	}
+
+	return nil
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	return err.Error()
+}

--- a/internal/qrunner/dockerengine/build_manager.go
+++ b/internal/qrunner/dockerengine/build_manager.go
@@ -274,6 +274,7 @@ func (m *buildManager) build(fqn, version string, bt buildtype.BuildType, spec c
 		case m.sem <- struct{}{}:
 			defer func() { <-m.sem }()
 		case <-m.mainCtx.Done():
+			// TODO: One context failure should not fail all concurrent requests for the same FQN.
 			m.finish(fqn, m.mainCtx.Err())
 			return
 		}

--- a/internal/qrunner/dockerengine/build_manager_test.go
+++ b/internal/qrunner/dockerengine/build_manager_test.go
@@ -1,0 +1,61 @@
+package dockerengine
+
+import (
+	"archive/tar"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/lodthe/clickhouse-playground/internal/cibuild"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildTarContext(t *testing.T) {
+	buf, err := buildTarContext()
+	require.NoError(t, err)
+
+	modes := make(map[string]int64)
+	tr := tar.NewReader(buf)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		modes[hdr.Name] = hdr.Mode
+	}
+
+	// All three vendored build-context files must be present at the root.
+	assert.Contains(t, modes, dockerfileName)
+	assert.Contains(t, modes, "docker_related_config.xml")
+	assert.Contains(t, modes, "entrypoint.sh")
+
+	// The entrypoint must be executable.
+	assert.Equal(t, int64(0o755), modes["entrypoint.sh"])
+	assert.Equal(t, int64(0o644), modes[dockerfileName])
+}
+
+func TestBuildArgs(t *testing.T) {
+	spec := cibuild.BuildSpec{
+		Version:      "26.3.14.45",
+		DownloadURLs: []string{"https://x/a.deb", "https://x/b.deb"},
+	}
+
+	args := buildArgs(spec)
+
+	require.Contains(t, args, "DIRECT_DOWNLOAD_URLS")
+	require.Contains(t, args, "VERSION")
+	assert.Equal(t, "https://x/a.deb https://x/b.deb", *args["DIRECT_DOWNLOAD_URLS"])
+	assert.Equal(t, "26.3.14.45", *args["VERSION"])
+}
+
+func TestBuildManagerDisabled(t *testing.T) {
+	var m *buildManager
+	assert.False(t, m.enabled())
+
+	m = newBuildManager(context.Background(), zerolog.Nop(), nil, nil, BuildSettings{Enabled: false})
+	assert.False(t, m.enabled())
+}

--- a/internal/qrunner/dockerengine/buildcontext/Dockerfile.ubuntu
+++ b/internal/qrunner/dockerengine/buildcontext/Dockerfile.ubuntu
@@ -1,0 +1,166 @@
+FROM ubuntu:22.04
+
+# see https://github.com/moby/moby/issues/4032#issuecomment-192327844
+# It could be removed after we move on a version 23:04+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ARG for quick switch to a given ubuntu mirror
+ARG apt_archive="http://archive.ubuntu.com"
+
+# We shouldn't use `apt upgrade` to not change the upstream image. It's updated biweekly
+
+# user/group precreated explicitly with fixed uid/gid on purpose.
+# It is especially important for rootless containers: in that case entrypoint
+# can't do chown and owners of mounted volumes should be configured externally.
+# We do that in advance at the begining of Dockerfile before any packages will be
+# installed to prevent picking those uid / gid by some unrelated software.
+# The same uid / gid (101) is used both for alpine and ubuntu.
+RUN sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list \
+    && groupadd -r clickhouse --gid=101 \
+    && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \
+    && apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        busybox \
+        ca-certificates \
+        locales \
+        tzdata \
+        wget \
+    && busybox --install -s \
+    && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
+
+ARG REPO_CHANNEL="stable"
+ARG REPOSITORY="deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb ${REPO_CHANNEL} main"
+ARG VERSION="26.5.2.39"
+ARG PACKAGES="clickhouse-client clickhouse-server clickhouse-common-static"
+
+#docker-official-library:off
+# The part between `docker-official-library` tags is related to our builds
+
+# set non-empty deb_location_url url to create a docker image
+# from debs created by CI build, for example:
+# docker build . --network host --build-arg version="21.4.1.6282" --build-arg deb_location_url="https://..." -t ...
+ARG deb_location_url=""
+ARG DIRECT_DOWNLOAD_URLS=""
+
+# set non-empty single_binary_location_url to create docker image
+# from a single binary url (useful for non-standard builds - with sanitizers, for arm64).
+ARG single_binary_location_url=""
+
+ARG TARGETARCH
+
+# Number of `wget` retries and delay between them, for resilience against
+# transient HTTP errors (e.g. `clickhouse-builds.s3.amazonaws.com` returning
+# `500 Internal Server Error` / `503 Service Unavailable` during builds).
+ARG WGET_RETRIES=5
+ARG WGET_RETRY_DELAY=1
+
+# install from direct URL
+RUN wget_with_retry() { \
+        local attempt=1; \
+        while [ "$attempt" -le "${WGET_RETRIES}" ]; do \
+            if wget --progress=bar:force:noscroll "$@"; then return 0; fi; \
+            echo "Attempt $attempt/${WGET_RETRIES} failed, retrying in ${WGET_RETRY_DELAY}s..."; \
+            sleep "${WGET_RETRY_DELAY}"; \
+            attempt=$((attempt + 1)); \
+        done; \
+        echo "ERROR: Failed to download after ${WGET_RETRIES} attempts"; return 1; \
+    } \
+    && if [ -n "${DIRECT_DOWNLOAD_URLS}" ]; then \
+        echo "installing from custom predefined urls with deb packages: ${DIRECT_DOWNLOAD_URLS}" \
+        && rm -rf /tmp/clickhouse_debs \
+        && mkdir -p /tmp/clickhouse_debs \
+        && for url in $DIRECT_DOWNLOAD_URLS; do \
+            wget_with_retry "$url" -P /tmp/clickhouse_debs || exit 1 \
+        ; done \
+        && dpkg -i /tmp/clickhouse_debs/*.deb \
+        && rm -rf /tmp/* ; \
+    fi
+
+# install from a web location with deb packages
+RUN arch="${TARGETARCH:-amd64}" \
+    && if [ -n "${deb_location_url}" ]; then \
+        echo "installing from custom url with deb packages: ${deb_location_url}" \
+        && rm -rf /tmp/clickhouse_debs \
+        && mkdir -p /tmp/clickhouse_debs \
+        && for package in ${PACKAGES}; do \
+            { wget --progress=bar:force:noscroll "${deb_location_url}/${package}_${VERSION}_${arch}.deb" -P /tmp/clickhouse_debs || \
+                wget --progress=bar:force:noscroll "${deb_location_url}/${package}_${VERSION}_all.deb" -P /tmp/clickhouse_debs ; } \
+            || exit 1 \
+        ; done \
+        && dpkg -i /tmp/clickhouse_debs/*.deb \
+        && rm -rf /tmp/* ; \
+    fi
+
+# install from a single binary
+RUN if [ -n "${single_binary_location_url}" ]; then \
+        echo "installing from single binary url: ${single_binary_location_url}" \
+        && rm -rf /tmp/clickhouse_binary \
+        && mkdir -p /tmp/clickhouse_binary \
+        && wget --progress=bar:force:noscroll "${single_binary_location_url}" -O /tmp/clickhouse_binary/clickhouse \
+        && chmod +x /tmp/clickhouse_binary/clickhouse \
+        && /tmp/clickhouse_binary/clickhouse install --user "clickhouse" --group "clickhouse" \
+        && rm -rf /tmp/* ; \
+    fi
+
+# The rest is the same in the official docker and in our build system
+#docker-official-library:on
+
+# A fallback to installation from ClickHouse repository
+# It works unless the clickhouse binary already exists
+RUN clickhouse local -q 'SELECT 1' >/dev/null 2>&1 && exit 0 || : \
+    ; apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        dirmngr \
+        gnupg2 \
+    && mkdir -p /etc/apt/sources.list.d \
+    && GNUPGHOME=$(mktemp -d) \
+    && ( set +e; \
+        for KEYSERVER in \
+            hkp://keys.openpgp.org:80 \
+            hkp://pgp.mit.edu:80 \
+            hkp://keyserver.ubuntu.com:80; do \
+            GNUPGHOME="$GNUPGHOME" gpg --batch --no-default-keyring \
+                --keyring /usr/share/keyrings/clickhouse-keyring.gpg \
+                --keyserver "$KEYSERVER" \
+                --recv-keys 3a9ea1193a97b548be1457d48919f6bd2b48d754 && break; \
+        done || exit 1 \
+    ) \
+    && rm -rf "$GNUPGHOME" \
+    && chmod +r /usr/share/keyrings/clickhouse-keyring.gpg \
+    && echo "${REPOSITORY}" > /etc/apt/sources.list.d/clickhouse.list \
+    && echo "installing from repository: ${REPOSITORY}" \
+    && apt-get update \
+    && for package in ${PACKAGES}; do \
+        packages="${packages} ${package}=${VERSION}" \
+    ; done \
+    && apt-get install --yes --no-install-recommends ${packages} || exit 1 \
+    && rm -rf \
+        /var/lib/apt/lists/* \
+        /var/cache/debconf \
+        /tmp/* \
+    && apt-get autoremove --purge -yq dirmngr gnupg2 \
+    && chmod ugo+Xrw -R /etc/clickhouse-server /etc/clickhouse-client
+# The last chmod is here to make the next one is No-op in docker official library Dockerfile
+
+# post install
+# we need to allow "others" access to clickhouse folder, because docker container
+# can be started with arbitrary uid (openshift usecase)
+RUN clickhouse-local -q 'SELECT * FROM system.build_options' \
+    && mkdir -p /var/lib/clickhouse /var/log/clickhouse-server /etc/clickhouse-server /etc/clickhouse-client \
+    && chmod ugo+Xrw -R /var/lib/clickhouse /var/log/clickhouse-server /etc/clickhouse-server /etc/clickhouse-client
+
+RUN locale-gen en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV TZ=UTC
+
+RUN mkdir /docker-entrypoint-initdb.d
+
+COPY docker_related_config.xml /etc/clickhouse-server/config.d/
+COPY entrypoint.sh /entrypoint.sh
+
+EXPOSE 9000 8123 9009
+VOLUME /var/lib/clickhouse
+
+ENV CLICKHOUSE_CONFIG=/etc/clickhouse-server/config.xml
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/internal/qrunner/dockerengine/buildcontext/README.md
+++ b/internal/qrunner/dockerengine/buildcontext/README.md
@@ -1,0 +1,18 @@
+# Vendored ClickHouse server image build context
+
+These files are copied verbatim from the official ClickHouse server image build context
+and are embedded into the binary (see `../embed.go`). They are used to build debug and
+sanitizer images locally from CI `.deb` packages via the `DIRECT_DOWNLOAD_URLS` build arg.
+
+Source: `docker/server/` in https://github.com/ClickHouse/ClickHouse
+Pinned ref: `994f9d377c7adbe567ef3ba42a2e6b3a4f482e0b`
+
+Files:
+- `Dockerfile.ubuntu`
+- `docker_related_config.xml`
+- `entrypoint.sh`
+
+Keeping a verbatim copy means locally built images set up the `clickhouse` user,
+directories, and entrypoint exactly like the public release images the playground pulls
+from Docker Hub. To update, re-copy all three files from the same upstream ref and bump
+the ref above.

--- a/internal/qrunner/dockerengine/buildcontext/docker_related_config.xml
+++ b/internal/qrunner/dockerengine/buildcontext/docker_related_config.xml
@@ -1,0 +1,12 @@
+<clickhouse>
+     <!-- Listen wildcard address to allow accepting connections from other containers and host network. -->
+    <listen_host>::</listen_host>
+    <listen_host>0.0.0.0</listen_host>
+    <listen_try>1</listen_try>
+
+    <!--
+    <logger>
+        <console>1</console>
+    </logger>
+    -->
+</clickhouse>

--- a/internal/qrunner/dockerengine/buildcontext/entrypoint.sh
+++ b/internal/qrunner/dockerengine/buildcontext/entrypoint.sh
@@ -1,0 +1,272 @@
+#!/bin/bash
+
+set -eo pipefail
+shopt -s nullglob
+
+DO_CHOWN=1
+if [[ "${CLICKHOUSE_RUN_AS_ROOT:=0}" = "1" || "${CLICKHOUSE_DO_NOT_CHOWN:-0}" = "1" ]]; then
+    DO_CHOWN=0
+fi
+
+# support `docker run --user=xxx:xxxx`
+if [[ "$(id -u)" = "0" ]]; then
+    if [[ "$CLICKHOUSE_RUN_AS_ROOT" = 1 ]]; then
+        USER=0
+        GROUP=0
+    else
+        USER="${CLICKHOUSE_UID:-"$(id -u clickhouse)"}"
+        GROUP="${CLICKHOUSE_GID:-"$(id -g clickhouse)"}"
+    fi
+else
+    USER="$(id -u)"
+    GROUP="$(id -g)"
+    DO_CHOWN=0
+fi
+
+# set some vars
+CLICKHOUSE_CONFIG="${CLICKHOUSE_CONFIG:-/etc/clickhouse-server/config.xml}"
+
+# get CH directories locations
+DATA_DIR="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=path || true)"
+TMP_DIR="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=tmp_path || true)"
+USER_PATH="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=user_files_path || true)"
+LOG_PATH="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=logger.log --try || true)"
+LOG_DIR=""
+if [ -n "$LOG_PATH" ]; then LOG_DIR="$(dirname "$LOG_PATH")"; fi
+ERROR_LOG_PATH="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=logger.errorlog --try || true)"
+ERROR_LOG_DIR=""
+if [ -n "$ERROR_LOG_PATH" ]; then ERROR_LOG_DIR="$(dirname "$ERROR_LOG_PATH")"; fi
+FORMAT_SCHEMA_PATH="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=format_schema_path || true)"
+
+# There could be many disks declared in config
+readarray -t DISKS_PATHS < <(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key='storage_configuration.disks.*.path' || true)
+readarray -t DISKS_METADATA_PATHS < <(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key='storage_configuration.disks.*.metadata_path' || true)
+
+CLICKHOUSE_USER="${CLICKHOUSE_USER:-default}"
+CLICKHOUSE_PASSWORD_FILE="${CLICKHOUSE_PASSWORD_FILE:-}"
+if [[ -n "${CLICKHOUSE_PASSWORD_FILE}" && -f "${CLICKHOUSE_PASSWORD_FILE}" ]]; then
+    CLICKHOUSE_PASSWORD="$(cat "${CLICKHOUSE_PASSWORD_FILE}")"
+fi
+CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD:-}"
+CLICKHOUSE_DB="${CLICKHOUSE_DB:-}"
+CLICKHOUSE_ACCESS_MANAGEMENT="${CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT:-0}"
+CLICKHOUSE_SKIP_USER_SETUP="${CLICKHOUSE_SKIP_USER_SETUP:-0}"
+
+function create_directory_and_do_chown() {
+    local dir=$1
+    # check if variable not empty
+    [ -z "$dir" ] && return
+    # ensure directories exist
+    if [ "$DO_CHOWN" = "1" ]; then
+        mkdir=( mkdir )
+    else
+        # if DO_CHOWN=0 it means that the system does not map root user to "admin" permissions
+        # it mainly happens on NFS mounts where root==nobody for security reasons
+        # thus mkdir MUST run with user id/gid and not from nobody that has zero permissions
+        mkdir=( clickhouse su "${USER}:${GROUP}" mkdir )
+    fi
+    if ! "${mkdir[@]}" -p "$dir"; then
+        echo "Couldn't create necessary directory: $dir"
+        exit 1
+    fi
+
+    if [ "$DO_CHOWN" = "1" ]; then
+        # ensure proper directories permissions
+        # but skip it for if directory already has proper premissions, cause recursive chown may be slow
+        if [ "$(stat -c %u "$dir")" != "$USER" ] || [ "$(stat -c %g "$dir")" != "$GROUP" ]; then
+            chown -R "$USER:$GROUP" "$dir"
+        fi
+    fi
+}
+
+function manage_clickhouse_directories() {
+    for dir in "$ERROR_LOG_DIR" \
+      "$LOG_DIR" \
+      "$TMP_DIR" \
+      "$USER_PATH" \
+      "$FORMAT_SCHEMA_PATH" \
+      "${DISKS_PATHS[@]}" \
+      "${DISKS_METADATA_PATHS[@]}"
+    do
+        create_directory_and_do_chown "$dir"
+    done
+}
+
+function manage_clickhouse_user() {
+    # Check if the `defaul` user is changed through any mounted file. It will mean that user took care of it already
+    # First, extract the users_xml.path and check it's relative or absolute
+    local USERS_XML USERS_CONFIG
+    USERS_XML=$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key='user_directories.users_xml.path')
+    case $USERS_XML in
+        /* ) # absolute path
+            cp "$USERS_XML" /tmp
+            USERS_CONFIG="/tmp/$(basename $USERS_XML)"
+            ;;
+        * ) # relative path to the $CLICKHOUSE_CONFIG
+            cp "$(dirname "$CLICKHOUSE_CONFIG")/${USERS_XML}" /tmp
+            USERS_CONFIG="/tmp/$(basename $USERS_XML)"
+            ;;
+    esac
+
+    # Compare original `users.default` to the processed one
+    local ORIGINAL_DEFAULT PROCESSED_DEFAULT CLICKHOUSE_DEFAULT_CHANGED
+    ORIGINAL_DEFAULT=$(clickhouse extract-from-config --config-file "$USERS_CONFIG" --key='users.default' | sha256sum)
+    PROCESSED_DEFAULT=$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --users --key='users.default' --try | sha256sum)
+    [ "$ORIGINAL_DEFAULT" == "$PROCESSED_DEFAULT" ] && CLICKHOUSE_DEFAULT_CHANGED=0 || CLICKHOUSE_DEFAULT_CHANGED=1
+
+    if [ "$CLICKHOUSE_SKIP_USER_SETUP" == "1" ]; then
+        echo "$0: explicitly skip changing user 'default'"
+    elif [ -n "$CLICKHOUSE_USER" ] && [ "$CLICKHOUSE_USER" != "default" ] || [ -n "$CLICKHOUSE_PASSWORD" ] || [ "$CLICKHOUSE_ACCESS_MANAGEMENT" != "0" ]; then
+        # if clickhouse user is defined - create it (user "default" already exists out of box)
+        echo "$0: create new user '$CLICKHOUSE_USER' instead 'default'"
+        cat <<EOT > /etc/clickhouse-server/users.d/default-user.xml
+<clickhouse>
+  <!-- Docs: <https://clickhouse.com/docs/operations/settings/settings_users/> -->
+  <users>
+    <!-- Remove default user -->
+    <default remove="remove">
+    </default>
+
+    <${CLICKHOUSE_USER}>
+      <profile>default</profile>
+      <networks>
+        <ip>::/0</ip>
+      </networks>
+      <password><![CDATA[${CLICKHOUSE_PASSWORD//]]>/]]]]><![CDATA[>}]]></password>
+      <quota>default</quota>
+      <access_management>${CLICKHOUSE_ACCESS_MANAGEMENT}</access_management>
+    </${CLICKHOUSE_USER}>
+  </users>
+</clickhouse>
+EOT
+    elif [ "$CLICKHOUSE_DEFAULT_CHANGED" == "1" ]; then
+        # Leave users as is, do nothing
+        :
+    else
+        echo "$0: neither CLICKHOUSE_USER nor CLICKHOUSE_PASSWORD is set, disabling network access for user '$CLICKHOUSE_USER'"
+        cat <<EOT > /etc/clickhouse-server/users.d/default-user.xml
+<clickhouse>
+  <!-- Docs: <https://clickhouse.com/docs/operations/settings/settings_users/> -->
+  <users>
+    <default>
+      <!-- User default is available only locally -->
+      <networks>
+        <ip>::1</ip>
+        <ip>127.0.0.1</ip>
+      </networks>
+    </default>
+  </users>
+</clickhouse>
+EOT
+    fi
+}
+
+CLICKHOUSE_ALWAYS_RUN_INITDB_SCRIPTS="${CLICKHOUSE_ALWAYS_RUN_INITDB_SCRIPTS:-}"
+
+function init_clickhouse_db() {
+    # checking $DATA_DIR for initialization
+    if [ -d "${DATA_DIR%/}/data" ]; then
+        DATABASE_ALREADY_EXISTS='true'
+    fi
+
+    # run initialization if flag CLICKHOUSE_ALWAYS_RUN_INITDB_SCRIPTS is not empty or data directory is empty
+    if [[ -n "${CLICKHOUSE_ALWAYS_RUN_INITDB_SCRIPTS}" || -z "${DATABASE_ALREADY_EXISTS}" ]]; then
+      RUN_INITDB_SCRIPTS='true'
+    fi
+
+    if [ -n "${RUN_INITDB_SCRIPTS}" ]; then
+        if [ -n "$(ls /docker-entrypoint-initdb.d/)" ] || [ -n "$CLICKHOUSE_DB" ]; then
+            # port is needed to check if clickhouse-server is ready for connections
+            HTTP_PORT="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=http_port --try)"
+            HTTPS_PORT="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=https_port --try)"
+            NATIVE_PORT="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=tcp_port --try)"
+
+            if [ -n "$HTTP_PORT" ]; then
+                URL="http://127.0.0.1:$HTTP_PORT/ping"
+            else
+                URL="https://127.0.0.1:$HTTPS_PORT/ping"
+            fi
+
+            # Listen only on localhost until the initialization is done
+            clickhouse su "${USER}:${GROUP}" clickhouse-server --config-file="$CLICKHOUSE_CONFIG" -- --listen_host=127.0.0.1 &
+            pid="$!"
+
+            # check if clickhouse is ready to accept connections
+            # will try to send ping clickhouse via http_port (max 1000 retries by default, with 1 sec timeout and 1 sec delay between retries)
+            tries=${CLICKHOUSE_INIT_TIMEOUT:-1000}
+            while ! wget --spider --no-check-certificate -T 1 -q "$URL" 2>/dev/null; do
+                if [ "$tries" -le "0" ]; then
+                    echo >&2 'ClickHouse init process timeout.'
+                    exit 1
+                fi
+                tries=$(( tries-1 ))
+                sleep 1
+            done
+
+            clickhouseclient=( clickhouse-client --multiquery --host "127.0.0.1" --port "$NATIVE_PORT" -u "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" )
+
+            echo
+
+            # create default database, if defined
+            if [ -n "$CLICKHOUSE_DB" ]; then
+                echo "$0: create database '$CLICKHOUSE_DB'"
+                "${clickhouseclient[@]}" -q "CREATE DATABASE IF NOT EXISTS $CLICKHOUSE_DB";
+            fi
+
+            for f in /docker-entrypoint-initdb.d/*; do
+                case "$f" in
+                    *.sh)
+                        if [ -x "$f" ]; then
+                            echo "$0: running $f"
+                            "$f"
+                        else
+                            echo "$0: sourcing $f"
+                            # shellcheck source=/dev/null
+                            . "$f"
+                        fi
+                        ;;
+                    *.sql)    echo "$0: running $f"; "${clickhouseclient[@]}" < "$f" ; echo ;;
+                    *.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${clickhouseclient[@]}"; echo ;;
+                    *)        echo "$0: ignoring $f" ;;
+                esac
+                echo
+            done
+
+            if ! kill -s TERM "$pid" || ! wait "$pid"; then
+                echo >&2 'Finishing of ClickHouse init process failed.'
+                exit 1
+            fi
+        fi
+    else
+        echo "ClickHouse Database directory appears to contain a database; Skipping initialization"
+    fi
+}
+
+# if no args passed to `docker run` or first argument start with `--`, then the user is passing clickhouse-server arguments
+if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
+    # Watchdog is launched by default, but does not send SIGINT to the main process,
+    # so the container can't be finished by ctrl+c
+    CLICKHOUSE_WATCHDOG_ENABLE=${CLICKHOUSE_WATCHDOG_ENABLE:-0}
+    export CLICKHOUSE_WATCHDOG_ENABLE
+
+    create_directory_and_do_chown "$DATA_DIR"
+
+    # Change working directory to $DATA_DIR in case there're paths relative to $DATA_DIR, also avoids running
+    # clickhouse-server at root directory.
+    cd "$DATA_DIR"
+
+    # Using functions here to avoid unnecessary work in case of launching other binaries,
+    # inspired by postgres, mariadb etc. entrypoints
+    # It is necessary to pass the docker library consistency test
+    manage_clickhouse_directories
+    manage_clickhouse_user
+    init_clickhouse_db
+
+    # This replaces the shell script with the server:
+    exec clickhouse su "${USER}:${GROUP}" clickhouse-server --config-file="$CLICKHOUSE_CONFIG" "$@"
+fi
+
+# Otherwise, we assume the user want to run his own process, for example a `bash` shell to explore this image
+exec "$@"
+
+# vi: ts=4: sw=4: sts=4: expandtab

--- a/internal/qrunner/dockerengine/config.go
+++ b/internal/qrunner/dockerengine/config.go
@@ -23,6 +23,21 @@ type Config struct {
 	StatusCollectionFrequency time.Duration
 
 	Container ContainerSettings
+
+	// Builds configures local image builds for non-release (debug/sanitizer) build types.
+	Builds BuildSettings
+}
+
+type BuildSettings struct {
+	// Enabled turns on local image builds. When false, non-release builds are rejected.
+	Enabled bool
+
+	// Timeout bounds a single image build. Debug/sanitizer images are large and slow to
+	// download and install, so this should be generous.
+	Timeout time.Duration
+
+	// MaxConcurrent limits the number of concurrent image builds. 0 means unlimited.
+	MaxConcurrent uint
 }
 
 type ContainerSettings struct {
@@ -78,4 +93,13 @@ var DefaultConfig = Config{
 		CPUSet:      "",
 		MemoryLimit: 1 * 1e9,
 	},
+
+	Builds: BuildSettings{
+		Enabled:       false,
+		Timeout:       DefaultBuildTimeout,
+		MaxConcurrent: 1,
+	},
 }
+
+// DefaultBuildTimeout bounds a single local image build.
+const DefaultBuildTimeout = 45 * time.Minute

--- a/internal/qrunner/dockerengine/docker_image_name.go
+++ b/internal/qrunner/dockerengine/docker_image_name.go
@@ -1,8 +1,12 @@
 package dockerengine
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
+
+	"github.com/lodthe/clickhouse-playground/internal/buildtype"
 )
 
 func FullImageName(repository, version string) string {
@@ -13,6 +17,38 @@ func PlaygroundImageName(repository, digest string) string {
 	return fmt.Sprintf("chp-%s:%s", repository, strings.TrimPrefix(digest, "sha256:"))
 }
 
+// PlaygroundBuildImageName builds a deterministic, content-addressed name for a locally
+// built (debug/sanitizer) image. The download-URLs hash in the tag makes the name change
+// whenever the underlying artifacts change, so the same name can be safely reused as a cache
+// key across requests and restarts. The "chp-" prefix keeps it subject to the same image GC
+// as pulled images (see IsPlaygroundImageName).
+func PlaygroundBuildImageName(bt buildtype.BuildType, version string, downloadURLs []string) string {
+	repo := fmt.Sprintf("chp-build-%s-%s", bt, sanitizeRef(version))
+
+	return fmt.Sprintf("%s:%s", repo, hashURLs(downloadURLs))
+}
+
 func IsPlaygroundImageName(name string) bool {
 	return strings.HasPrefix(name, "chp-")
+}
+
+// hashURLs returns a short hex digest of the download URLs, usable as a Docker image tag.
+func hashURLs(urls []string) string {
+	sum := sha256.Sum256([]byte(strings.Join(urls, "\n")))
+
+	return hex.EncodeToString(sum[:])[:32]
+}
+
+// sanitizeRef replaces characters that are invalid in a Docker image name component with '-'.
+func sanitizeRef(s string) string {
+	s = strings.ToLower(s)
+
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			return r
+		default:
+			return '-'
+		}
+	}, s)
 }

--- a/internal/qrunner/dockerengine/docker_image_name_test.go
+++ b/internal/qrunner/dockerengine/docker_image_name_test.go
@@ -1,7 +1,10 @@
 package dockerengine
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/lodthe/clickhouse-playground/internal/buildtype"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -48,4 +51,30 @@ func TestIsPlaygroundImageName(t *testing.T) {
 
 	assert.True(t, IsPlaygroundImageName(chp))
 	assert.False(t, IsPlaygroundImageName(notChp))
+}
+
+func TestPlaygroundBuildImageName(t *testing.T) {
+	urls := []string{"https://x/clickhouse-server_26.3.14.45_amd64.deb"}
+
+	name := PlaygroundBuildImageName(buildtype.ASAN, "26.3.14.45", urls)
+
+	assert.True(t, strings.HasPrefix(name, "chp-build-asan-26.3.14.45:"), name)
+	assert.True(t, IsPlaygroundImageName(name))
+
+	// Deterministic for the same inputs.
+	assert.Equal(t, name, PlaygroundBuildImageName(buildtype.ASAN, "26.3.14.45", urls))
+
+	// Changes when the artifacts change.
+	other := PlaygroundBuildImageName(buildtype.ASAN, "26.3.14.45", []string{"https://x/other.deb"})
+	assert.NotEqual(t, name, other)
+
+	// Tag part is a valid 32-char hex digest.
+	tag := name[strings.LastIndex(name, ":")+1:]
+	assert.Len(t, tag, 32)
+}
+
+func TestSanitizeRef(t *testing.T) {
+	assert.Equal(t, "26.3.14.45", sanitizeRef("26.3.14.45"))
+	assert.Equal(t, "26.3.14.45-debug", sanitizeRef("26.3.14.45+debug"))
+	assert.Equal(t, "abc-def", sanitizeRef("ABC/def"))
 }

--- a/internal/qrunner/dockerengine/embed.go
+++ b/internal/qrunner/dockerengine/embed.go
@@ -1,0 +1,15 @@
+package dockerengine
+
+import "embed"
+
+// buildContextFS holds the vendored ClickHouse server image build context. It is used to
+// build debug/sanitizer images locally from CI .deb packages. See buildcontext/README.md.
+//
+//go:embed buildcontext/Dockerfile.ubuntu buildcontext/docker_related_config.xml buildcontext/entrypoint.sh
+var buildContextFS embed.FS
+
+// buildContextDir is the directory inside buildContextFS that holds the build context files.
+const buildContextDir = "buildcontext"
+
+// dockerfileName is the Dockerfile to use within the build context.
+const dockerfileName = "Dockerfile.ubuntu"

--- a/internal/qrunner/dockerengine/engine_provider.go
+++ b/internal/qrunner/dockerengine/engine_provider.go
@@ -1,7 +1,9 @@
 package dockerengine
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	dockercli "github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/pkg/errors"
 )
 
@@ -21,10 +24,15 @@ const DefaultDockerTimeout = 5 * time.Minute
 type engineProvider struct {
 	mainCtx context.Context
 	cli     *dockercli.Client
+
+	// buildCli is a separate client used for image builds. Builds stream output for the
+	// whole build duration, so it must not carry the short per-request timeout that cli
+	// uses; build deadlines are enforced via the context instead.
+	buildCli *dockercli.Client
 }
 
 func newProvider(ctx context.Context, daemonURL *string) (*engineProvider, error) {
-	opts, err := getDockerEngineOpts(daemonURL)
+	opts, err := getDockerEngineOpts(daemonURL, DefaultDockerTimeout)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build options for Docker client")
 	}
@@ -34,16 +42,30 @@ func newProvider(ctx context.Context, daemonURL *string) (*engineProvider, error
 		return nil, errors.Wrap(err, "failed to create Docker client")
 	}
 
+	// A client without an HTTP timeout for long-running image builds.
+	buildOpts, err := getDockerEngineOpts(daemonURL, 0)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build options for Docker build client")
+	}
+
+	buildCli, err := dockercli.NewClientWithOpts(buildOpts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create Docker build client")
+	}
+
 	return &engineProvider{
-		mainCtx: ctx,
-		cli:     cli,
+		mainCtx:  ctx,
+		cli:      cli,
+		buildCli: buildCli,
 	}, nil
 }
 
-func getDockerEngineOpts(daemonURL *string) ([]dockercli.Opt, error) {
+func getDockerEngineOpts(daemonURL *string, timeout time.Duration) ([]dockercli.Opt, error) {
 	opts := []dockercli.Opt{
 		dockercli.WithAPIVersionNegotiation(),
-		dockercli.WithTimeout(DefaultDockerTimeout),
+	}
+	if timeout > 0 {
+		opts = append(opts, dockercli.WithTimeout(timeout))
 	}
 
 	if daemonURL == nil {
@@ -90,6 +112,70 @@ func (p *engineProvider) pullImage(ctx context.Context, imageTag string) (io.Rea
 
 func (p *engineProvider) addImageTag(ctx context.Context, existingImageTag, newImageTag string) error {
 	return p.cli.ImageTag(ctx, existingImageTag, newImageTag)
+}
+
+// buildImage builds an image from the given tar build context and tags it with imageTag.
+// It blocks until the build finishes and returns an error if the build fails. onLine, if not
+// nil, is called with each non-empty output line so callers can report progress.
+func (p *engineProvider) buildImage(ctx context.Context, buildContext io.Reader, imageTag string, buildArgs map[string]*string, onLine func(string)) error {
+	resp, err := p.buildCli.ImageBuild(ctx, buildContext, types.ImageBuildOptions{
+		Tags:        []string{imageTag},
+		Dockerfile:  dockerfileName,
+		BuildArgs:   buildArgs,
+		Remove:      true,
+		ForceRemove: true,
+		// Don't force-pull the base image on every build; it is pulled if missing. Avoids a
+		// per-build round-trip to (anonymous, rate-limited) Docker Hub.
+		PullParent: false,
+	})
+	if err != nil {
+		return errors.Wrap(err, "image build request failed")
+	}
+	defer resp.Body.Close()
+
+	return readBuildOutput(resp.Body, onLine)
+}
+
+// readBuildOutput drains the Docker build output stream and returns an error if the build
+// reported one. The stream is a sequence of JSON messages; each carries either build step
+// output ("stream") or an image-pull status ("status"). onLine receives each non-empty line.
+func readBuildOutput(r io.Reader, onLine func(string)) error {
+	decoder := json.NewDecoder(r)
+	for {
+		var msg struct {
+			Stream      string `json:"stream"`
+			Status      string `json:"status"`
+			Error       string `json:"error"`
+			ErrorDetail struct {
+				Message string `json:"message"`
+			} `json:"errorDetail"`
+		}
+
+		err := decoder.Decode(&msg)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return errors.Wrap(err, "failed to read build output")
+		}
+
+		if msg.Error != "" {
+			return errors.New(msg.Error)
+		}
+		if msg.ErrorDetail.Message != "" {
+			return errors.New(msg.ErrorDetail.Message)
+		}
+
+		if onLine != nil {
+			if line := msg.Stream; line != "" {
+				onLine(line)
+			} else if msg.Status != "" {
+				onLine(msg.Status)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (p *engineProvider) getImageByID(ctx context.Context, id string) (image.InspectResponse, error) {
@@ -169,6 +255,27 @@ func (p *engineProvider) exec(ctx context.Context, containerID string, cmd []str
 	}
 
 	return resp, nil
+}
+
+// getContainerStderr returns the container's stderr stream. For non-TTY containers the log
+// stream is multiplexed, so it is demuxed and only the stderr portion is returned. The
+// clickhouse-server process writes sanitizer reports to stderr.
+func (p *engineProvider) getContainerStderr(ctx context.Context, containerID string) (string, error) {
+	reader, err := p.cli.ContainerLogs(ctx, containerID, container.LogsOptions{
+		ShowStdout: false,
+		ShowStderr: true,
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get container logs")
+	}
+	defer reader.Close()
+
+	var outBuf, errBuf bytes.Buffer
+	if _, err := stdcopy.StdCopy(&outBuf, &errBuf, reader); err != nil {
+		return "", errors.Wrap(err, "failed to demux container logs")
+	}
+
+	return errBuf.String(), nil
 }
 
 func (p *engineProvider) getContainers(ctx context.Context) ([]container.Summary, error) {

--- a/internal/qrunner/dockerengine/prewarmer.go
+++ b/internal/qrunner/dockerengine/prewarmer.go
@@ -133,11 +133,12 @@ func (p *prewarmer) extractNextRequest() (request requestState, count int) {
 
 func (p *prewarmer) runContainer(request *requestState) error {
 	state := requestState{
-		runID:    "PREWARMING",
-		query:    " ",
-		version:  request.version,
-		imageTag: request.imageTag,
-		imageFQN: request.imageFQN,
+		runID:     "PREWARMING",
+		query:     " ",
+		version:   request.version,
+		buildType: request.buildType,
+		imageTag:  request.imageTag,
+		imageFQN:  request.imageFQN,
 	}
 	err := p.runner.createContainer(p.ctx, &state)
 	if err != nil {

--- a/internal/qrunner/dockerengine/runner.go
+++ b/internal/qrunner/dockerengine/runner.go
@@ -534,7 +534,7 @@ func (r *Runner) collectSanitizerReport(ctx context.Context, state *requestState
 	stderr, err := r.engine.getContainerStderr(ctx, state.containerID)
 	if err != nil {
 		r.logger.Debug().Err(err).Str("run_id", state.runID).Msg("failed to read container stderr for sanitizer report")
-		return ""
+		return "<failed to collect stderr>"
 	}
 
 	return extractSanitizerReport(stderr)

--- a/internal/qrunner/dockerengine/runner.go
+++ b/internal/qrunner/dockerengine/runner.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/lodthe/clickhouse-playground/internal/buildtype"
+	"github.com/lodthe/clickhouse-playground/internal/cibuild"
 	"github.com/lodthe/clickhouse-playground/internal/dbsettings"
 	"github.com/lodthe/clickhouse-playground/internal/dbsettings/runsettings"
 	"github.com/lodthe/clickhouse-playground/internal/dockertag"
@@ -44,6 +46,7 @@ type Runner struct {
 
 	engine       *engineProvider
 	tagStorage   ImageStorage
+	builder      *buildManager
 	pipelineMetr *metrics.PipelineExporter
 
 	workers   sync.WaitGroup
@@ -52,7 +55,9 @@ type Runner struct {
 	prewarmer *prewarmer
 }
 
-func New(ctx context.Context, logger zerolog.Logger, name string, cfg Config, tagStorage ImageStorage) (*Runner, error) {
+// New creates a Docker Engine runner. resolver may be nil when local builds are disabled;
+// in that case only release (Docker Hub) builds are supported.
+func New(ctx context.Context, logger zerolog.Logger, name string, cfg Config, tagStorage ImageStorage, resolver cibuild.Resolver) (*Runner, error) {
 	engine, err := newProvider(ctx, cfg.DaemonURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create Docker engine provider")
@@ -70,6 +75,7 @@ func New(ctx context.Context, logger zerolog.Logger, name string, cfg Config, ta
 		cfg:          cfg,
 		engine:       engine,
 		tagStorage:   tagStorage,
+		builder:      newBuildManager(ctx, logger, engine, resolver, cfg.Builds),
 		pipelineMetr: metrics.NewPipelineExporter(string(qrunner.TypeDockerEngine), name),
 	}
 
@@ -142,15 +148,21 @@ func (r *Runner) Stop(shutdownCtx context.Context) error {
 }
 
 func (r *Runner) RunQuery(ctx context.Context, run *queryrun.Run) (output string, err error) {
-	state := &requestState{
-		runID:    run.ID,
-		database: run.Database,
-		version:  run.Version,
-		query:    run.Input,
-		settings: run.Settings,
+	bt, err := buildtype.Parse(run.BuildType)
+	if err != nil {
+		return "", err
 	}
 
-	state.imageTag, state.imageFQN, err = r.constructImageFQN(state.version)
+	state := &requestState{
+		runID:     run.ID,
+		database:  run.Database,
+		version:   run.Version,
+		buildType: bt,
+		query:     run.Input,
+		settings:  run.Settings,
+	}
+
+	state.imageTag, state.imageFQN, err = r.resolveImage(ctx, state.version, state.buildType)
 	if err != nil {
 		return "", fmt.Errorf("failed to construct FQN: %w", err)
 	}
@@ -201,13 +213,28 @@ func (r *Runner) RunQuery(ctx context.Context, run *queryrun.Run) (output string
 	return output, nil
 }
 
-// constructImageFQN builds image tag and FQN from version.
-// If there is no such a version, an error is returned.
+// resolveImage builds the image tag and FQN for a (version, build type) pair.
 //
-// Otherwise, an image is fetched and the following names are built:
-// - image tag: image name in format <repository>:<version>
-// - image FQN: a unique fully qualified name that includes the exact version of the image
-func (r *Runner) constructImageFQN(version string) (imageTag string, imageFQN string, err error) {
+// For release builds the image comes from Docker Hub:
+//   - image tag: image name in format <repository>:<version>
+//   - image FQN: a unique fully qualified name that includes the exact version of the image
+//
+// For non-release builds the image is built locally; the tag is empty and the FQN is a
+// content-addressed name derived from the resolved CI artifacts.
+func (r *Runner) resolveImage(ctx context.Context, version string, bt buildtype.BuildType) (imageTag string, imageFQN string, err error) {
+	if !bt.IsRelease() {
+		if !r.builder.enabled() {
+			return "", "", qrunner.ErrBuildsNotSupported
+		}
+
+		fqn, _, err := r.builder.resolve(ctx, version, bt)
+		if err != nil {
+			return "", "", err
+		}
+
+		return "", fqn, nil
+	}
+
 	img, found := r.tagStorage.Find(version)
 	if !found {
 		return "", "", errors.New("version not found")
@@ -219,27 +246,43 @@ func (r *Runner) constructImageFQN(version string) (imageTag string, imageFQN st
 	return imageTag, imageFQN, nil
 }
 
-// createContainer pulls image if necessary and runs a container with a database.
+// createContainer makes sure the image is present and runs a container with a database.
+// Release images are pulled on demand; non-release images must have been built beforehand
+// via EnsureImage (the prepare flow), otherwise ErrImageNotReady is returned.
 func (r *Runner) createContainer(ctx context.Context, state *requestState) error {
-	if state.imageFQN == "" || state.imageTag == "" {
+	if state.imageFQN == "" {
 		var err error
-		state.imageTag, state.imageFQN, err = r.constructImageFQN(state.version)
+		state.imageTag, state.imageFQN, err = r.resolveImage(ctx, state.version, state.buildType)
 		if err != nil {
 			return fmt.Errorf("failed to construct FQN: %w", err)
 		}
 	}
 
-	err := r.pull(ctx, state)
-	if err != nil {
-		return fmt.Errorf("pull failed: %w", err)
+	if state.buildType.IsRelease() {
+		err := r.pull(ctx, state)
+		if err != nil {
+			return fmt.Errorf("pull failed: %w", err)
+		}
+	} else if !r.checkIfImageExists(ctx, state) {
+		return qrunner.ErrImageNotReady
 	}
 
-	err = r.runContainer(ctx, state)
+	err := r.runContainer(ctx, state)
 	if err != nil {
 		return fmt.Errorf("container run failed: %w", err)
 	}
 
 	return err
+}
+
+// EnsureImage makes sure the image for the given version and build type is built and cached.
+func (r *Runner) EnsureImage(ctx context.Context, version string, bt buildtype.BuildType) (qrunner.ImageStatus, error) {
+	if bt.IsRelease() {
+		// Release images are pulled on demand inside RunQuery.
+		return qrunner.ImageStatus{State: qrunner.ImageReady}, nil
+	}
+
+	return r.builder.Ensure(ctx, version, bt)
 }
 
 // pull checks whether the requested image exists. If no, it will be downloaded and renamed to hashed-name.
@@ -467,9 +510,32 @@ func (r *Runner) runQueryWithContainer(ctx context.Context, state *requestState)
 		time.Sleep(r.cfg.ExecRetryDelay)
 	}
 
-	if stderr == "" {
-		return stdout, nil
+	output = stdout
+	if stderr != "" {
+		output = stdout + "\n" + stderr
 	}
 
-	return stdout + "\n" + stderr, nil
+	// Sanitizer/debug builds print sanitizer reports (data races, use-after-free, UB, ...) to
+	// the server's stderr, which the client never sees. Capture it and forward it to the user.
+	if !state.buildType.IsRelease() {
+		if report := r.collectSanitizerReport(ctx, state); report != "" {
+			if output != "" {
+				output += "\n\n"
+			}
+			output += report
+		}
+	}
+
+	return output, nil
+}
+
+// collectSanitizerReport reads the container's stderr and returns any sanitizer report found.
+func (r *Runner) collectSanitizerReport(ctx context.Context, state *requestState) string {
+	stderr, err := r.engine.getContainerStderr(ctx, state.containerID)
+	if err != nil {
+		r.logger.Debug().Err(err).Str("run_id", state.runID).Msg("failed to read container stderr for sanitizer report")
+		return ""
+	}
+
+	return extractSanitizerReport(stderr)
 }

--- a/internal/qrunner/dockerengine/runner_test.go
+++ b/internal/qrunner/dockerengine/runner_test.go
@@ -90,7 +90,7 @@ func TestCustomSettings(t *testing.T) {
 	}
 
 	rcfg := DefaultConfig
-	runner, _ := New(ctx, logger, "Test", rcfg, tagStorage)
+	runner, _ := New(ctx, logger, "Test", rcfg, tagStorage, nil)
 
 	for _, tc := range cases {
 		output, err := runner.RunQuery(ctx, &queryrun.Run{Input: tc.query, Version: tc.version, Database: tc.database, Settings: tc.runSettings})

--- a/internal/qrunner/dockerengine/sanitizer.go
+++ b/internal/qrunner/dockerengine/sanitizer.go
@@ -1,0 +1,54 @@
+package dockerengine
+
+import "strings"
+
+// maxSanitizerReportLines caps how many lines of a sanitizer report are forwarded to the client.
+const maxSanitizerReportLines = 400
+
+// sanitizerReportHeader prefixes a forwarded sanitizer report in the query output.
+const sanitizerReportHeader = "=== Sanitizer report ==="
+
+// sanitizerMarkers identify the start of a sanitizer report in a process's stderr. They match
+// AddressSanitizer/ThreadSanitizer/MemorySanitizer/UndefinedBehaviorSanitizer reports (the
+// "...Sanitizer:" marker appears in their ERROR/WARNING/SUMMARY lines) and UBSan's inline
+// "runtime error:" lines.
+var sanitizerMarkers = []string{"Sanitizer:", "runtime error:"}
+
+func containsSanitizerMarker(line string) bool {
+	for _, marker := range sanitizerMarkers {
+		if strings.Contains(line, marker) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// extractSanitizerReport returns the sanitizer report found in a process's stderr, starting at
+// the first sanitizer marker, or "" if the stderr contains no sanitizer output. The result is
+// capped to maxSanitizerReportLines lines and prefixed with a header.
+func extractSanitizerReport(stderr string) string {
+	if stderr == "" {
+		return ""
+	}
+
+	lines := strings.Split(stderr, "\n")
+
+	start := -1
+	for i, line := range lines {
+		if containsSanitizerMarker(line) {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return ""
+	}
+
+	report := lines[start:]
+	if len(report) > maxSanitizerReportLines {
+		report = report[:maxSanitizerReportLines]
+	}
+
+	return sanitizerReportHeader + "\n" + strings.Join(report, "\n")
+}

--- a/internal/qrunner/dockerengine/sanitizer.go
+++ b/internal/qrunner/dockerengine/sanitizer.go
@@ -34,18 +34,18 @@ func extractSanitizerReport(stderr string) string {
 
 	lines := strings.Split(stderr, "\n")
 
-	start := -1
+	var start *int
 	for i, line := range lines {
 		if containsSanitizerMarker(line) {
-			start = i
+			start = &i
 			break
 		}
 	}
-	if start < 0 {
+	if start == nil {
 		return ""
 	}
 
-	report := lines[start:]
+	report := lines[*start:]
 	if len(report) > maxSanitizerReportLines {
 		report = report[:maxSanitizerReportLines]
 	}

--- a/internal/qrunner/dockerengine/sanitizer_test.go
+++ b/internal/qrunner/dockerengine/sanitizer_test.go
@@ -1,0 +1,63 @@
+package dockerengine
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractSanitizerReport(t *testing.T) {
+	const asan = `Some normal server startup line
+==42==ERROR: AddressSanitizer: heap-use-after-free on address 0x602000000010
+    #0 0x55 in DB::doThing()
+SUMMARY: AddressSanitizer: heap-use-after-free src/X.cpp:10 in DB::doThing()
+==42==ABORTING`
+
+	report := extractSanitizerReport(asan)
+	if !strings.HasPrefix(report, sanitizerReportHeader) {
+		t.Fatalf("missing header: %q", report)
+	}
+	if !strings.Contains(report, "AddressSanitizer: heap-use-after-free") {
+		t.Errorf("report missing the error line: %q", report)
+	}
+	// The normal startup line precedes the first marker and must be excluded.
+	if strings.Contains(report, "normal server startup line") {
+		t.Errorf("report should start at the first sanitizer marker: %q", report)
+	}
+}
+
+func TestExtractSanitizerReportVariants(t *testing.T) {
+	cases := map[string]string{
+		"tsan":  "WARNING: ThreadSanitizer: data race (pid=1)\nSUMMARY: ThreadSanitizer: data race src/Y.cpp:3",
+		"msan":  "==7==WARNING: MemorySanitizer: use-of-uninitialized-value\nSUMMARY: MemorySanitizer: use-of-uninitialized-value",
+		"ubsan": "src/Z.cpp:5:9: runtime error: signed integer overflow",
+	}
+	for name, stderr := range cases {
+		if got := extractSanitizerReport(stderr); got == "" {
+			t.Errorf("%s: expected a report, got empty", name)
+		}
+	}
+}
+
+func TestExtractSanitizerReportNoMarker(t *testing.T) {
+	clean := "Processing configuration file.\nLogging to /var/log/clickhouse-server.\nReady for connections."
+	if got := extractSanitizerReport(clean); got != "" {
+		t.Errorf("expected no report for clean stderr, got %q", got)
+	}
+	if got := extractSanitizerReport(""); got != "" {
+		t.Errorf("expected empty for empty stderr, got %q", got)
+	}
+}
+
+func TestExtractSanitizerReportCap(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("ERROR: AddressSanitizer: heap-buffer-overflow\n")
+	for i := 0; i < maxSanitizerReportLines*2; i++ {
+		b.WriteString("    #frame line\n")
+	}
+
+	report := extractSanitizerReport(b.String())
+	// header + at most maxSanitizerReportLines report lines.
+	if lines := strings.Count(report, "\n"); lines > maxSanitizerReportLines+1 {
+		t.Errorf("report not capped: %d lines", lines)
+	}
+}

--- a/internal/qrunner/dockerengine/state.go
+++ b/internal/qrunner/dockerengine/state.go
@@ -1,6 +1,7 @@
 package dockerengine
 
 import (
+	"github.com/lodthe/clickhouse-playground/internal/buildtype"
 	"github.com/lodthe/clickhouse-playground/internal/dbsettings/runsettings"
 )
 
@@ -8,9 +9,10 @@ import (
 type requestState struct {
 	runID string
 
-	database string
-	version  string
-	query    string
+	database  string
+	version   string
+	buildType buildtype.BuildType
+	query     string
 
 	settings runsettings.RunSettings
 

--- a/internal/qrunner/image.go
+++ b/internal/qrunner/image.go
@@ -1,0 +1,36 @@
+package qrunner
+
+import "github.com/pkg/errors"
+
+// ImageState describes the readiness of an image that must be built locally
+// (debug/sanitizer builds) before a query can run against it.
+type ImageState string
+
+const (
+	// ImageBuilding means the image is being built (or about to be).
+	ImageBuilding ImageState = "building"
+	// ImageReady means the image is present and a query can run against it.
+	ImageReady ImageState = "ready"
+	// ImageFailed means the last build attempt failed.
+	ImageFailed ImageState = "failed"
+)
+
+// ImageStatus is the result of an EnsureImage call.
+type ImageStatus struct {
+	State ImageState `json:"state"`
+	// Detail is a human-readable progress stage while State is ImageBuilding
+	// (e.g. "Downloading packages", "Installing packages").
+	Detail string `json:"detail,omitempty"`
+	// Logs is a tail of the build output, streamed while State is ImageBuilding.
+	Logs string `json:"logs,omitempty"`
+	// Error holds the failure reason when State is ImageFailed.
+	Error string `json:"error,omitempty"`
+}
+
+// ErrImageNotReady is returned by RunQuery when a non-release image has not been built yet.
+// Callers should trigger EnsureImage (the prepare flow) and retry once it is ready.
+var ErrImageNotReady = errors.New("image is not ready, prepare it first")
+
+// ErrBuildsNotSupported is returned when a non-release build is requested but the runner
+// is not configured to build images locally.
+var ErrBuildsNotSupported = errors.New("local builds are not supported by this runner")

--- a/internal/qrunner/runner.go
+++ b/internal/qrunner/runner.go
@@ -3,6 +3,7 @@ package qrunner
 import (
 	"context"
 
+	"github.com/lodthe/clickhouse-playground/internal/buildtype"
 	"github.com/lodthe/clickhouse-playground/internal/queryrun"
 )
 
@@ -13,6 +14,11 @@ type Runner interface {
 	Status(ctx context.Context) RunnerStatus
 
 	RunQuery(ctx context.Context, run *queryrun.Run) (string, error)
+
+	// EnsureImage makes sure the image for the given version and build type is present,
+	// building it in the background if necessary. It returns the current build status and
+	// is non-blocking. For release builds it always reports ImageReady.
+	EnsureImage(ctx context.Context, version string, bt buildtype.BuildType) (ImageStatus, error)
 
 	// Start initializes background processes (like garbage collection and status exporter).
 	// This function is non-blocking.

--- a/internal/qrunner/stubrunner/runner.go
+++ b/internal/qrunner/stubrunner/runner.go
@@ -3,6 +3,7 @@ package stubrunner
 import (
 	"context"
 
+	"github.com/lodthe/clickhouse-playground/internal/buildtype"
 	"github.com/lodthe/clickhouse-playground/internal/qrunner"
 	"github.com/lodthe/clickhouse-playground/internal/queryrun"
 
@@ -55,4 +56,12 @@ func (r *Runner) Stop(_ context.Context) error {
 
 func (r *Runner) RunQuery(ctx context.Context, run *queryrun.Run) (string, error) {
 	return r.run(ctx, run)
+}
+
+func (r *Runner) EnsureImage(_ context.Context, _ string, bt buildtype.BuildType) (qrunner.ImageStatus, error) {
+	if bt.IsRelease() {
+		return qrunner.ImageStatus{State: qrunner.ImageReady}, nil
+	}
+
+	return qrunner.ImageStatus{}, qrunner.ErrBuildsNotSupported
 }

--- a/internal/queryrun/run.go
+++ b/internal/queryrun/run.go
@@ -12,8 +12,10 @@ type Run struct {
 	ID string `dynamodbav:"Id"`
 
 	Version string `dynamodbav:"Version"`
-	Input   string `dynamodbav:"Input"`
-	Output  string `dynamodbav:"Output"`
+	// BuildType is the ClickHouse build kind (release/debug/asan/...). Empty means release.
+	BuildType string `dynamodbav:"BuildType"`
+	Input     string `dynamodbav:"Input"`
+	Output    string `dynamodbav:"Output"`
 
 	Database string                  `dynamodbav:"Database"`
 	Settings runsettings.RunSettings `dynamodbav:"Settings"`
@@ -22,13 +24,14 @@ type Run struct {
 	ExecutionTime time.Duration `dynamodbav:"ExecutionTime"`
 }
 
-func New(input string, database string, version string, settings runsettings.RunSettings) *Run {
+func New(input string, database string, version string, buildType string, settings runsettings.RunSettings) *Run {
 	return &Run{
 		ID:        uuid.New().String(),
 		CreatedAt: time.Now(),
 		Input:     input,
 		Database:  database,
 		Version:   version,
+		BuildType: buildType,
 		Settings:  settings,
 	}
 }

--- a/openapi.yml
+++ b/openapi.yml
@@ -16,12 +16,12 @@ paths:
       description: Returns a list of available ClickHouse version tags that can be used for running queries
       operationId: getImageTags
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetImageTagsResponse'
+                $ref: "#/components/schemas/GetImageTagsResponse"
 
   /build-types:
     get:
@@ -29,12 +29,12 @@ paths:
       description: Returns the list of selectable ClickHouse build types (release, debug, sanitizers)
       operationId: getBuildTypes
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetBuildTypesResponse'
+                $ref: "#/components/schemas/GetBuildTypesResponse"
 
   /images/prepare:
     post:
@@ -50,26 +50,26 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PrepareImageRequest'
+              $ref: "#/components/schemas/PrepareImageRequest"
       responses:
-        '200':
+        "200":
           description: Current build state
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ImageStatusResponse'
-        '400':
+                $ref: "#/components/schemas/ImageStatusResponse"
+        "400":
           description: Bad request (empty/unknown version or unknown build type)
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '501':
+                $ref: "#/components/schemas/ErrorResponse"
+        "501":
           description: Local builds are not enabled
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse" # TODO: Add examples of errors.
 
   /images/status:
     get:
@@ -86,20 +86,20 @@ paths:
           in: query
           required: true
           schema:
-            $ref: '#/components/schemas/BuildType'
+            $ref: "#/components/schemas/BuildType"
       responses:
-        '200':
+        "200":
           description: Current build state
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ImageStatusResponse'
-        '400':
+                $ref: "#/components/schemas/ImageStatusResponse"
+        "400":
           description: Bad request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
 
   /runs:
     post:
@@ -111,20 +111,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RunQueryRequest'
+              $ref: "#/components/schemas/RunQueryRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RunQueryResponse'
-        '400':
+                $ref: "#/components/schemas/RunQueryResponse"
+        "400":
           description: Bad request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               examples:
                 emptyQuery:
                   value:
@@ -151,32 +151,32 @@ paths:
                     error:
                       message: unknown database
                       code: 400
-        '409':
+        "409":
           description: The requested non-release image has not been built yet
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               example:
                 error:
                   message: image is not ready, prepare it first
                   code: 409
-        '429':
+        "429":
           description: Too many requests
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               example:
                 error:
                   message: no available runners
                   code: 429
-        '501':
+        "501":
           description: A non-release build was requested but local builds are not enabled
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
 
   /runs/{id}:
     get:
@@ -192,28 +192,28 @@ paths:
             type: string
             format: uuid
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetQueryRunResponse'
-        '400':
+                $ref: "#/components/schemas/GetQueryRunResponse"
+        "400":
           description: Bad request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               example:
                 error:
                   message: missed id
                   code: 400
-        '404':
+        "404":
           description: Run not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               example:
                 error:
                   message: run not found
@@ -225,7 +225,7 @@ components:
       type: object
       properties:
         error:
-          $ref: '#/components/schemas/ErrorDetail'
+          $ref: "#/components/schemas/ErrorDetail"
       required:
         - error
 
@@ -279,7 +279,7 @@ components:
             build_types:
               type: array
               items:
-                $ref: '#/components/schemas/BuildType'
+                $ref: "#/components/schemas/BuildType"
           required:
             - build_types
       required:
@@ -287,12 +287,12 @@ components:
 
     PrepareImageRequest:
       type: object
-      properties:
+      properties: # TODO: Add examples of input values.
         version:
           type: string
           description: ClickHouse version tag (as returned by GET /tags)
         build_type:
-          $ref: '#/components/schemas/BuildType'
+          $ref: "#/components/schemas/BuildType"
       required:
         - version
         - build_type
@@ -331,7 +331,7 @@ components:
           type: string
           description: ClickHouse version tag to use
         build_type:
-          $ref: '#/components/schemas/BuildType'
+          $ref: "#/components/schemas/BuildType"
         database:
           type: string
           description: Database type (defaults to "clickhouse" if not specified)
@@ -391,7 +391,7 @@ components:
               type: string
               description: ClickHouse version tag used for the query
             build_type:
-              $ref: '#/components/schemas/BuildType'
+              $ref: "#/components/schemas/BuildType"
             settings:
               type: object
               description: Settings used for the query run

--- a/openapi.yml
+++ b/openapi.yml
@@ -23,6 +23,84 @@ paths:
               schema:
                 $ref: '#/components/schemas/GetImageTagsResponse'
 
+  /build-types:
+    get:
+      summary: Get available build types
+      description: Returns the list of selectable ClickHouse build types (release, debug, sanitizers)
+      operationId: getBuildTypes
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetBuildTypesResponse'
+
+  /images/prepare:
+    post:
+      summary: Prepare a non-release ClickHouse image
+      description: >
+        Triggers an asynchronous local build of a non-release (debug/sanitizer) image for the
+        given version and build type, returning immediately with the current build state.
+        Poll GET /images/status until the state is "ready" before running a query.
+        Release builds always return "ready".
+      operationId: prepareImage
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PrepareImageRequest'
+      responses:
+        '200':
+          description: Current build state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImageStatusResponse'
+        '400':
+          description: Bad request (empty/unknown version or unknown build type)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '501':
+          description: Local builds are not enabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /images/status:
+    get:
+      summary: Get the build state of a non-release image
+      description: Returns the current build state for a (version, build_type) pair.
+      operationId: getImageStatus
+      parameters:
+        - name: version
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: build_type
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/BuildType'
+      responses:
+        '200':
+          description: Current build state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImageStatusResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /runs:
     post:
       summary: Run a ClickHouse SQL query
@@ -73,6 +151,16 @@ paths:
                     error:
                       message: unknown database
                       code: 400
+        '409':
+          description: The requested non-release image has not been built yet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  message: image is not ready, prepare it first
+                  code: 409
         '429':
           description: Too many requests
           content:
@@ -83,6 +171,12 @@ paths:
                 error:
                   message: no available runners
                   code: 429
+        '501':
+          description: A non-release build was requested but local builds are not enabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /runs/{id}:
     get:
@@ -164,6 +258,69 @@ components:
       required:
         - result
 
+    BuildType:
+      type: string
+      description: ClickHouse build kind. "release" images come from Docker Hub; the others are built locally from CI artifacts.
+      default: release
+      enum:
+        - release
+        - debug
+        - asan
+        - tsan
+        - msan
+        - ubsan
+
+    GetBuildTypesResponse:
+      type: object
+      properties:
+        result:
+          type: object
+          properties:
+            build_types:
+              type: array
+              items:
+                $ref: '#/components/schemas/BuildType'
+          required:
+            - build_types
+      required:
+        - result
+
+    PrepareImageRequest:
+      type: object
+      properties:
+        version:
+          type: string
+          description: ClickHouse version tag (as returned by GET /tags)
+        build_type:
+          $ref: '#/components/schemas/BuildType'
+      required:
+        - version
+        - build_type
+
+    ImageStatusResponse:
+      type: object
+      properties:
+        result:
+          type: object
+          properties:
+            state:
+              type: string
+              enum:
+                - building
+                - ready
+                - failed
+              description: Current build state of the image
+            detail:
+              type: string
+              description: Human-readable progress stage while building (e.g. "Downloading packages", "Installing packages")
+            error:
+              type: string
+              description: Failure reason when state is "failed"
+          required:
+            - state
+      required:
+        - result
+
     RunQueryRequest:
       type: object
       properties:
@@ -173,6 +330,8 @@ components:
         version:
           type: string
           description: ClickHouse version tag to use
+        build_type:
+          $ref: '#/components/schemas/BuildType'
         database:
           type: string
           description: Database type (defaults to "clickhouse" if not specified)
@@ -231,6 +390,8 @@ components:
             version:
               type: string
               description: ClickHouse version tag used for the query
+            build_type:
+              $ref: '#/components/schemas/BuildType'
             settings:
               type: object
               description: Settings used for the query run

--- a/pkg/clickhousebuilds/client.go
+++ b/pkg/clickhousebuilds/client.go
@@ -1,0 +1,199 @@
+// Package clickhousebuilds is a client for discovering ClickHouse CI build artifacts.
+//
+// On release branches, ClickHouse CI (praktika) publishes debug and sanitizer .deb
+// packages to S3 and records their URLs in a per-commit report JSON. This client
+// resolves a released version to its commit sha (via the GitHub API) and fetches the
+// corresponding ReleaseBranchCI report.
+package clickhousebuilds
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+const (
+	// DefaultReportBaseURL is the S3 location that hosts praktika report JSON files.
+	DefaultReportBaseURL = "https://s3.amazonaws.com/clickhouse-test-reports"
+
+	// DefaultGitHubAPIURL is the GitHub REST API base URL.
+	DefaultGitHubAPIURL = "https://api.github.com"
+
+	// DefaultRepository is the ClickHouse GitHub repository.
+	DefaultRepository = "ClickHouse/ClickHouse"
+
+	// releaseBranchCIReportFile is the report file name for the ReleaseBranchCI workflow.
+	// It follows praktika's task-name normalization (lowercase, non-alphanumeric -> '_').
+	releaseBranchCIReportFile = "result_releasebranchci.json"
+
+	// errorBodyLimit bounds how much of an error response body is read for diagnostics.
+	errorBodyLimit = 512
+)
+
+// Client fetches ClickHouse CI metadata from S3 and GitHub.
+type Client struct {
+	reportBaseURL string
+	githubAPIURL  string
+	repository    string
+	githubToken   string
+
+	cli *http.Client
+	log zerolog.Logger
+}
+
+// Config configures a Client. Empty fields fall back to the Default* values.
+type Config struct {
+	ReportBaseURL string
+	GitHubAPIURL  string
+	Repository    string
+	// GitHubToken is optional; it raises the GitHub API rate limit when set.
+	GitHubToken string
+}
+
+func NewClient(log zerolog.Logger, cfg Config, httpCli ...*http.Client) *Client {
+	c := &Client{
+		reportBaseURL: cfg.ReportBaseURL,
+		githubAPIURL:  cfg.GitHubAPIURL,
+		repository:    cfg.Repository,
+		githubToken:   cfg.GitHubToken,
+		cli:           http.DefaultClient,
+		log:           log,
+	}
+
+	if c.reportBaseURL == "" {
+		c.reportBaseURL = DefaultReportBaseURL
+	}
+	if c.githubAPIURL == "" {
+		c.githubAPIURL = DefaultGitHubAPIURL
+	}
+	if c.repository == "" {
+		c.repository = DefaultRepository
+	}
+	if len(httpCli) == 1 && httpCli[0] != nil {
+		c.cli = httpCli[0]
+	}
+
+	return c
+}
+
+// ResolveCommitSHA resolves a git ref (a tag such as "v26.3.14.45-stable", a branch, or
+// a sha) to its commit sha using the GitHub API.
+func (c *Client) ResolveCommitSHA(ctx context.Context, ref string) (string, error) {
+	url := fmt.Sprintf("%s/repos/%s/commits/%s", c.githubAPIURL, c.repository, ref)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create request")
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if c.githubToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.githubToken)
+	}
+
+	resp, err := c.cli.Do(req)
+	if err != nil {
+		return "", errors.Wrap(err, "github request failed")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", errors.Errorf("ref %q not found", ref)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, errorBodyLimit))
+		return "", errors.Errorf("github returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var payload struct {
+		SHA string `json:"sha"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", errors.Wrap(err, "failed to decode github response")
+	}
+	if payload.SHA == "" {
+		return "", errors.Errorf("github returned empty sha for ref %q", ref)
+	}
+
+	return payload.SHA, nil
+}
+
+// GetRecentCommitSHAs returns up to limit of the most recent commit shas on a release branch
+// ref (e.g. "26.3"), newest first. It reads the branch's commits.json, where commits are
+// ordered oldest to newest.
+func (c *Client) GetRecentCommitSHAs(ctx context.Context, ref string, limit int) ([]string, error) {
+	url := fmt.Sprintf("%s/REFs/%s/commits.json", c.reportBaseURL, ref)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create request")
+	}
+
+	resp, err := c.cli.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "commits request failed")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound {
+		return nil, errors.Errorf("no release branch %q found (status %d)", ref, resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, errorBodyLimit))
+		return nil, errors.Errorf("commits request returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var commits []struct {
+		SHA string `json:"sha"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&commits); err != nil {
+		return nil, errors.Wrap(err, "failed to decode commits")
+	}
+
+	shas := make([]string, 0, limit)
+	for i := len(commits) - 1; i >= 0 && len(shas) < limit; i-- {
+		if commits[i].SHA != "" {
+			shas = append(shas, commits[i].SHA)
+		}
+	}
+
+	return shas, nil
+}
+
+// GetReleaseBranchReport fetches the ReleaseBranchCI report for the given release-branch
+// ref (e.g. "26.3") and commit sha.
+func (c *Client) GetReleaseBranchReport(ctx context.Context, ref, sha string) (*Report, error) {
+	url := fmt.Sprintf("%s/REFs/%s/%s/%s", c.reportBaseURL, ref, sha, releaseBranchCIReportFile)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create request")
+	}
+
+	resp, err := c.cli.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "report request failed")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound {
+		return nil, errors.Errorf("report for %s@%s does not exist or expired (status %d)", ref, sha, resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, errorBodyLimit))
+		return nil, errors.Errorf("report request returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	report := new(Report)
+	if err := json.NewDecoder(resp.Body).Decode(report); err != nil {
+		return nil, errors.Wrap(err, "failed to decode report")
+	}
+
+	c.log.Debug().Str("ref", ref).Str("sha", sha).Int("results", len(report.Results)).Msg("fetched release branch report")
+
+	return report, nil
+}

--- a/pkg/clickhousebuilds/client.go
+++ b/pkg/clickhousebuilds/client.go
@@ -65,6 +65,7 @@ func NewClient(log zerolog.Logger, cfg Config, httpCli ...*http.Client) *Client 
 		log:           log,
 	}
 
+	// TODO: Move default value substitution to the config layer.
 	if c.reportBaseURL == "" {
 		c.reportBaseURL = DefaultReportBaseURL
 	}

--- a/pkg/clickhousebuilds/client_test.go
+++ b/pkg/clickhousebuilds/client_test.go
@@ -1,0 +1,83 @@
+package clickhousebuilds
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestResolveCommitSHA(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/ClickHouse/ClickHouse/commits/v26.3.14.45-stable" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"sha":"276eb5833a3b176e90709028a6ddd6ee29aa29c4"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(zerolog.Nop(), Config{GitHubAPIURL: srv.URL})
+	sha, err := c.ResolveCommitSHA(context.Background(), "v26.3.14.45-stable")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sha != "276eb5833a3b176e90709028a6ddd6ee29aa29c4" {
+		t.Errorf("sha = %q", sha)
+	}
+}
+
+func TestResolveCommitSHANotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewClient(zerolog.Nop(), Config{GitHubAPIURL: srv.URL})
+	if _, err := c.ResolveCommitSHA(context.Background(), "v0.0.0.0-stable"); err == nil {
+		t.Error("expected error for 404")
+	}
+}
+
+func TestGetReleaseBranchReport(t *testing.T) {
+	const body = `{"name":"ReleaseBranchCI","status":"success","results":[
+		{"name":"Build (amd_asan)","status":"success","links":["https://x/clickhouse-server_26.3.14.45_amd64.deb"]}
+	]}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/REFs/26.3/abc/result_releasebranchci.json" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := NewClient(zerolog.Nop(), Config{ReportBaseURL: srv.URL})
+	report, err := c.GetReleaseBranchReport(context.Background(), "26.3", "abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	job, ok := report.FindResult("Build (amd_asan)")
+	if !ok {
+		t.Fatal("expected to find Build (amd_asan)")
+	}
+	if len(job.Links) != 1 {
+		t.Errorf("links = %v", job.Links)
+	}
+}
+
+func TestGetReleaseBranchReportExpired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := NewClient(zerolog.Nop(), Config{ReportBaseURL: srv.URL})
+	if _, err := c.GetReleaseBranchReport(context.Background(), "26.3", "abc"); err == nil {
+		t.Error("expected error for expired/missing report")
+	}
+}

--- a/pkg/clickhousebuilds/models.go
+++ b/pkg/clickhousebuilds/models.go
@@ -1,0 +1,80 @@
+package clickhousebuilds
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Report is a partial view of a ClickHouse CI (praktika) result JSON document,
+// e.g. result_releasebranchci.json. Only the fields the playground needs are decoded.
+type Report struct {
+	Name    string   `json:"name"`
+	Status  string   `json:"status"`
+	Results []Result `json:"results"`
+}
+
+// Result is a single CI check. Build jobs (e.g. "Build (amd_asan)") expose their
+// produced package URLs in Links. Results may be nested.
+type Result struct {
+	Name    string   `json:"name"`
+	Status  string   `json:"status"`
+	Links   []string `json:"links"`
+	Results []Result `json:"results"`
+}
+
+// successStatuses are the status strings praktika uses for a passed check. The value has
+// varied across report versions ("success" on older reports, "OK" on newer ones).
+var successStatuses = map[string]bool{"success": true, "ok": true}
+
+// IsSuccessStatus reports whether a praktika check status means the check passed.
+func IsSuccessStatus(status string) bool {
+	return successStatuses[strings.ToLower(strings.TrimSpace(status))]
+}
+
+// FindResult performs a depth-first search for a result with the exact given name.
+// It returns the first match and whether one was found.
+func (r *Report) FindResult(name string) (Result, bool) {
+	return findResult(r.Results, name)
+}
+
+func findResult(results []Result, name string) (Result, bool) {
+	for _, res := range results {
+		if res.Name == name {
+			return res, true
+		}
+		if nested, ok := findResult(res.Results, name); ok {
+			return nested, true
+		}
+	}
+
+	return Result{}, false
+}
+
+// amdBuildRe matches an amd64 package build job, capturing the underscore-separated variant
+// tokens. The CI matrix sometimes combines variants into one job, e.g. "Build (amd_asan_ubsan)".
+var amdBuildRe = regexp.MustCompile(`^Build \(amd_(.+)\)$`)
+
+// AMDBuildJob returns the first successful amd64 build job that produces the given variant
+// (debug/asan/tsan/msan/ubsan). It matches by token, so a combined job such as
+// "Build (amd_asan_ubsan)" satisfies both "asan" and "ubsan".
+func (r *Report) AMDBuildJob(variant string) (Result, bool) {
+	return findAMDBuild(r.Results, variant)
+}
+
+func findAMDBuild(results []Result, variant string) (Result, bool) {
+	for _, res := range results {
+		match := amdBuildRe.FindStringSubmatch(res.Name)
+		if match != nil && IsSuccessStatus(res.Status) {
+			for _, token := range strings.Split(match[1], "_") {
+				if strings.EqualFold(token, variant) {
+					return res, true
+				}
+			}
+		}
+		if nested, ok := findAMDBuild(res.Results, variant); ok {
+			return nested, true
+		}
+	}
+
+	return Result{}, false
+}

--- a/pkg/clickhousebuilds/models_test.go
+++ b/pkg/clickhousebuilds/models_test.go
@@ -1,0 +1,64 @@
+package clickhousebuilds
+
+import "testing"
+
+func TestFindResultNested(t *testing.T) {
+	report := &Report{
+		Results: []Result{
+			{Name: "top"},
+			{Name: "parent", Results: []Result{
+				{Name: "child", Status: "success"},
+			}},
+		},
+	}
+
+	if _, ok := report.FindResult("top"); !ok {
+		t.Error("expected to find top-level result")
+	}
+
+	child, ok := report.FindResult("child")
+	if !ok {
+		t.Fatal("expected to find nested result")
+	}
+	if child.Status != "success" {
+		t.Errorf("child.Status = %q", child.Status)
+	}
+
+	if _, ok := report.FindResult("missing"); ok {
+		t.Error("did not expect to find a missing result")
+	}
+}
+
+func TestAMDBuildJob(t *testing.T) {
+	report := &Report{
+		Results: []Result{
+			{Name: "Build (amd_release)", Status: "OK"},
+			{Name: "Build (amd_debug)", Status: "success"}, // older "success" status
+			{Name: "Build (amd_asan_ubsan)", Status: "OK"}, // newer "OK" status
+			{Name: "Build (amd_tsan)", Status: "failure"},
+			{Name: "Build (arm_msan)", Status: "OK"},
+		},
+	}
+
+	cases := map[string]struct {
+		wantName string
+		wantOK   bool
+	}{
+		"debug": {"Build (amd_debug)", true},
+		"asan":  {"Build (amd_asan_ubsan)", true}, // combined job matches by token
+		"ubsan": {"Build (amd_asan_ubsan)", true},
+		"tsan":  {"", false}, // present but failed
+		"msan":  {"", false}, // only arm built
+	}
+
+	for variant, want := range cases {
+		job, ok := report.AMDBuildJob(variant)
+		if ok != want.wantOK {
+			t.Errorf("AMDBuildJob(%q) ok = %v, want %v", variant, ok, want.wantOK)
+			continue
+		}
+		if ok && job.Name != want.wantName {
+			t.Errorf("AMDBuildJob(%q) = %q, want %q", variant, job.Name, want.wantName)
+		}
+	}
+}

--- a/pkg/dockerhub/client.go
+++ b/pkg/dockerhub/client.go
@@ -52,6 +52,13 @@ func NewClient(log zerolog.Logger, apiURL string, maxRPS int, auth Auth, httpCli
 }
 
 func (c *Client) getAccessToken() (string, error) {
+	// Docker Hub allows anonymous listing of public repositories' tags (with stricter rate
+	// limits). When no credentials are configured, skip token acquisition and fall back to
+	// anonymous access instead of failing.
+	if c.auth.Identifier == "" || c.auth.Secret == "" {
+		return "", nil
+	}
+
 	url := fmt.Sprintf("%s/auth/token", c.apiURL)
 
 	request, err := json.Marshal(c.auth)
@@ -122,7 +129,9 @@ func (c *Client) getTags(url string, token string) (*GetImageTagsResponse, error
 		return nil, fmt.Errorf("failed to create http request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+token)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 
 	resp, err := c.cli.Do(req)
 	if err != nil {

--- a/pkg/dockerhub/client.go
+++ b/pkg/dockerhub/client.go
@@ -55,6 +55,7 @@ func (c *Client) getAccessToken() (string, error) {
 	// Docker Hub allows anonymous listing of public repositories' tags (with stricter rate
 	// limits). When no credentials are configured, skip token acquisition and fall back to
 	// anonymous access instead of failing.
+	// TODO: Add an explicit config option for public repositories, which use anonymous access.
 	if c.auth.Identifier == "" || c.auth.Secret == "" {
 		return "", nil
 	}

--- a/pkg/restapi/deps.go
+++ b/pkg/restapi/deps.go
@@ -3,7 +3,9 @@ package restapi
 import (
 	"context"
 
+	"github.com/lodthe/clickhouse-playground/internal/buildtype"
 	"github.com/lodthe/clickhouse-playground/internal/dockertag"
+	"github.com/lodthe/clickhouse-playground/internal/qrunner"
 	"github.com/lodthe/clickhouse-playground/internal/queryrun"
 )
 
@@ -14,4 +16,9 @@ type TagStorage interface {
 
 type QueryRunner interface {
 	RunQuery(ctx context.Context, run *queryrun.Run) (string, error)
+}
+
+// ImagePreparer triggers and reports on local image builds for non-release build types.
+type ImagePreparer interface {
+	EnsureImage(ctx context.Context, version string, bt buildtype.BuildType) (qrunner.ImageStatus, error)
 }

--- a/pkg/restapi/image_build.go
+++ b/pkg/restapi/image_build.go
@@ -1,0 +1,118 @@
+package restapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/lodthe/clickhouse-playground/internal/buildtype"
+	"github.com/lodthe/clickhouse-playground/internal/qrunner"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/pkg/errors"
+	zlog "github.com/rs/zerolog/log"
+)
+
+type imageBuildHandler struct {
+	preparer   ImagePreparer
+	tagStorage TagStorage
+}
+
+func newImageBuildHandler(preparer ImagePreparer, storage TagStorage) *imageBuildHandler {
+	return &imageBuildHandler{
+		preparer:   preparer,
+		tagStorage: storage,
+	}
+}
+
+func (h *imageBuildHandler) handle(r chi.Router) {
+	r.Get("/build-types", h.getBuildTypes)
+	r.Post("/images/prepare", h.prepareImage)
+	r.Get("/images/status", h.getImageStatus)
+}
+
+type GetBuildTypesOutput struct {
+	BuildTypes []string `json:"build_types"`
+}
+
+func (h *imageBuildHandler) getBuildTypes(w http.ResponseWriter, _ *http.Request) {
+	types := buildtype.All()
+
+	names := make([]string, 0, len(types))
+	for _, t := range types {
+		names = append(names, t.String())
+	}
+
+	writeResult(w, GetBuildTypesOutput{BuildTypes: names})
+}
+
+type PrepareImageInput struct {
+	Version   string `json:"version"`
+	BuildType string `json:"build_type"`
+}
+
+type ImageStatusOutput struct {
+	State  string `json:"state"`
+	Detail string `json:"detail,omitempty"`
+	Logs   string `json:"logs,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+func (h *imageBuildHandler) prepareImage(w http.ResponseWriter, r *http.Request) {
+	var req PrepareImageInput
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	h.ensure(w, r, req.Version, req.BuildType)
+}
+
+func (h *imageBuildHandler) getImageStatus(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	h.ensure(w, r, q.Get("version"), q.Get("build_type"))
+}
+
+// ensure validates the inputs and reports the build status. It is shared by the prepare
+// (POST) and status (GET) endpoints: EnsureImage is idempotent and starts a build only when
+// one is needed, so polling it is safe.
+func (h *imageBuildHandler) ensure(w http.ResponseWriter, r *http.Request, version, rawBuildType string) {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		writeError(w, "version cannot be empty", http.StatusBadRequest)
+		return
+	}
+	if !h.tagStorage.Exists(version) {
+		writeError(w, fmt.Sprintf("unknown version: %q", version), http.StatusBadRequest)
+		return
+	}
+
+	bt, err := buildtype.Parse(rawBuildType)
+	if err != nil {
+		writeError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	status, err := h.preparer.EnsureImage(r.Context(), version, bt)
+	if err != nil {
+		switch {
+		case errors.Is(err, qrunner.ErrBuildsNotSupported):
+			writeError(w, err.Error(), http.StatusNotImplemented)
+		case errors.Is(err, qrunner.ErrNoAvailableRunners):
+			writeError(w, err.Error(), http.StatusTooManyRequests)
+		default:
+			zlog.Error().Err(err).Str("version", version).Str("build_type", bt.String()).Msg("failed to prepare image")
+			writeError(w, err.Error(), http.StatusBadRequest)
+		}
+
+		return
+	}
+
+	writeResult(w, ImageStatusOutput{
+		State:  string(status.State),
+		Detail: status.Detail,
+		Logs:   status.Logs,
+		Error:  status.Error,
+	})
+}

--- a/pkg/restapi/image_build.go
+++ b/pkg/restapi/image_build.go
@@ -78,6 +78,7 @@ func (h *imageBuildHandler) getImageStatus(w http.ResponseWriter, r *http.Reques
 // (POST) and status (GET) endpoints: EnsureImage is idempotent and starts a build only when
 // one is needed, so polling it is safe.
 func (h *imageBuildHandler) ensure(w http.ResponseWriter, r *http.Request, version, rawBuildType string) {
+	// TODO: Have a helper function to ensure version existence.
 	version = strings.TrimSpace(version)
 	if version == "" {
 		writeError(w, "version cannot be empty", http.StatusBadRequest)

--- a/pkg/restapi/query_runner.go
+++ b/pkg/restapi/query_runner.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
+	"github.com/lodthe/clickhouse-playground/internal/buildtype"
 	"github.com/lodthe/clickhouse-playground/internal/dbsettings/runsettings"
 	"github.com/lodthe/clickhouse-playground/internal/qrunner"
 	"github.com/lodthe/clickhouse-playground/internal/queryrun"
@@ -45,10 +47,12 @@ func (h *queryHandler) handle(r chi.Router) {
 }
 
 type RunQueryInput struct {
-	Query    string      `json:"query"`
-	Version  string      `json:"version"`
-	Database string      `json:"database"`
-	Settings RunSettings `json:"settings"`
+	Query   string `json:"query"`
+	Version string `json:"version"`
+	// BuildType is the ClickHouse build kind: "release" (default), "debug", "asan", etc.
+	BuildType string      `json:"build_type"`
+	Database  string      `json:"database"`
+	Settings  RunSettings `json:"settings"`
 }
 
 type RunSettings struct {
@@ -104,8 +108,15 @@ func (h *queryHandler) runQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	req.Version = strings.TrimSpace(req.Version)
 	if !h.tagStorage.Exists(req.Version) {
-		writeError(w, "unknown version", http.StatusBadRequest)
+		writeError(w, fmt.Sprintf("unknown version: %q", req.Version), http.StatusBadRequest)
+		return
+	}
+
+	bt, err := buildtype.Parse(req.BuildType)
+	if err != nil {
+		writeError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -120,7 +131,7 @@ func (h *queryHandler) runQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	run := queryrun.New(req.Query, req.Database, req.Version, runSettings)
+	run := queryrun.New(req.Query, req.Database, req.Version, bt.String(), runSettings)
 
 	startedAt := time.Now()
 	output, err := h.r.RunQuery(r.Context(), run)
@@ -130,6 +141,12 @@ func (h *queryHandler) runQuery(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, qrunner.ErrNoAvailableRunners):
 			writeError(w, err.Error(), http.StatusTooManyRequests)
+
+		case errors.Is(err, qrunner.ErrImageNotReady):
+			writeError(w, err.Error(), http.StatusConflict)
+
+		case errors.Is(err, qrunner.ErrBuildsNotSupported):
+			writeError(w, err.Error(), http.StatusNotImplemented)
 
 		default:
 			writeError(w, "internal error", http.StatusInternalServerError)
@@ -173,6 +190,7 @@ type GetQueryRunOutput struct {
 	QueryRunID string                  `json:"query_run_id"`
 	Database   string                  `json:"database,omitempty"`
 	Version    string                  `json:"version"`
+	BuildType  string                  `json:"build_type,omitempty"`
 	Settings   runsettings.RunSettings `json:"settings,omitempty"`
 	Input      string                  `json:"input"`
 	Output     string                  `json:"output"`
@@ -201,6 +219,7 @@ func (h *queryHandler) getQueryRun(w http.ResponseWriter, r *http.Request) {
 		QueryRunID: run.ID,
 		Database:   run.Database,
 		Version:    run.Version,
+		BuildType:  run.BuildType,
 		Settings:   run.Settings,
 		Input:      run.Input,
 		Output:     run.Output,

--- a/pkg/restapi/router.go
+++ b/pkg/restapi/router.go
@@ -18,6 +18,7 @@ import (
 type RouterOpts struct {
 	Logger     zerolog.Logger
 	Runner     QueryRunner
+	Preparer   ImagePreparer
 	TagStorage TagStorage
 	RunRepo    queryrun.Repository
 
@@ -58,6 +59,7 @@ func NewRouter(opts RouterOpts) http.Handler {
 	r.Route("/api", func(r chi.Router) {
 		newQueryHandler(opts.Runner, opts.RunRepo, opts.TagStorage, opts.MaxQueryLength, opts.MaxOutputLength).handle(r)
 		newImageTagHandler(opts.TagStorage).handle(r)
+		newImageBuildHandler(opts.Preparer, opts.TagStorage).handle(r)
 	})
 
 	return r


### PR DESCRIPTION
## What

Adds support for running non-release ClickHouse builds — **debug, asan, tsan, msan, ubsan** — alongside the existing release builds.

Release images are still pulled from Docker Hub. For the other build types, the backend resolves the `.deb` packages produced by ClickHouse CI on release branches, builds a Docker image locally (a vendored copy of `docker/server/Dockerfile.ubuntu` + the `DIRECT_DOWNLOAD_URLS` build arg), caches it, and runs the query against it through the existing container/exec pipeline.

## How it works

These images are large (~8–9 GB) and slow to build (~6–7 min), so building is asynchronous:

| Endpoint | Purpose |
|---|---|
| `GET /api/build-types` | list selectable build types |
| `POST /api/images/prepare` | start a background build; returns `{state, detail, logs}` |
| `GET /api/images/status?version=&build_type=` | poll build state + stage + live logs |
| `POST /api/runs` | now accepts `build_type`; returns `409` until the image is ready |

**Resolution** (`pkg/clickhousebuilds` + `internal/cibuild`): version → commit sha (GitHub) → ReleaseBranchCI report → package URLs. Matches the build job by variant token (handles the combined `amd_asan_ubsan` job), accepts both `success`/`OK` statuses, and falls back to recent branch commits for `major.minor` refs.

**Image build** (`internal/qrunner/dockerengine`): single-flight, bounded concurrency, content-addressed `chp-build-*` names (so the existing image GC applies), staged progress (`Downloading packages`, `Installing packages`, …) + ANSI-stripped streamed build logs, and **sanitizer-report capture** from the container's stderr (forwarded to the client).

`EnsureImage` is added to the runner interface with coordinator fan-out (ready only when all alive runners have the image).

## Supporting changes
- List Docker Hub tags **anonymously** when no auth is configured (the tags API is public); credentials become optional and only raise the rate limit.
- Optional `aws.endpoint_url` to point DynamoDB at a local instance.
- Load image tags **synchronously at startup** so valid versions aren't rejected during the first background fetch.

## Config
New `docker_image.builds` block (disabled by default) — documented in `config.yml`.

## Try it locally
`deploy/local/` has a credential-free `docker-compose` stack (backend + UI + local DynamoDB). See `deploy/local/README.md`. Companion UI changes are in a separate PR on `clickhouse-playground-ui`.

> Note: tsan/msan runtime needs the host's `vm.mmap_rnd_bits <= 28` (ASLR); asan/ubsan/debug/release work as-is.

## Testing
`go test ./...`, `go vet`, and `golangci-lint` (v2.1) all clean. Verified end-to-end locally: release runs unchanged; asan/ubsan/debug images build from CI artifacts and run (`SELECT value FROM system.build_options WHERE name='CXX_FLAGS'` shows `sanitize=address`), build_type persists, and re-prepare is an instant cache hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
